### PR TITLE
Fix #8: Add support for V4 tokens calculation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "cc7"]
+	path = cc7
+	url = ../cc7.git
+	branch = develop

--- a/PowerAuth2ForWatch.podspec
+++ b/PowerAuth2ForWatch.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
     s.summary           = 'PowerAuth Mobile SDK for watchOS'
     s.homepage          = 'https://github.com/wultra/powerauth-mobile-sdk'
     s.social_media_url  = 'https://twitter.com/wultra'
-    s.documentation_url = 'https://developers.wultra.com/products/mobile-security-suite/develop/powerauth-mobile-sdk/PowerAuth-SDK-for-watchOS'
+    s.documentation_url = 'https://github.com/wultra/powerauth-mobile-sdk/blob/develop/docs/PowerAuth-SDK-for-watchOS.md'
     s.author            = { 
       'Wultra s.r.o.' => 'support@wultra.com'
     }
@@ -18,7 +18,8 @@ Pod::Spec.new do |s|
     # Source files
     s.source = { 
         :git => 'https://github.com/wultra/powerauth-mobile-watch-sdk.git',
-        :tag => "#{s.version}"
+        :tag => "#{s.version}",
+        :submodules => true
     }
     
     # Library build

--- a/PowerAuth2ForWatch.xcodeproj/project.pbxproj
+++ b/PowerAuth2ForWatch.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -77,7 +77,19 @@
 		BF86E8D7263C2BBF004C8AE5 /* PA2CoreCryptoUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = BF86E8D5263C2BBF004C8AE5 /* PA2CoreCryptoUtils.m */; };
 		BFC1929827FC694A001455C1 /* PowerAuthSharingConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC1929627FC694A001455C1 /* PowerAuthSharingConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFC1929927FC694A001455C1 /* PowerAuthSharingConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = BFC1929727FC694A001455C1 /* PowerAuthSharingConfiguration.m */; };
+		BFFC5E162F7160FF00A1411B /* PA2ActivationStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = BFFC5E152F7160FF00A1411B /* PA2ActivationStatus.m */; };
+		BFFC5E172F7160FF00A1411B /* PA2ActivationStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = BFFC5E142F7160FF00A1411B /* PA2ActivationStatus.h */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		BFFC5E0A2F6D85F200A1411B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFFC5E062F6D6B5E00A1411B /* openssl.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = BFFC5DD82F6D62F800A1411B;
+			remoteInfo = OpenSSL;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		BF1ED078283D01CC00D6B380 /* PowerAuthKeychainAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PowerAuthKeychainAuthentication.h; sourceTree = "<group>"; };
@@ -153,6 +165,9 @@
 		BF86E8D5263C2BBF004C8AE5 /* PA2CoreCryptoUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2CoreCryptoUtils.m; sourceTree = "<group>"; };
 		BFC1929627FC694A001455C1 /* PowerAuthSharingConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PowerAuthSharingConfiguration.h; sourceTree = "<group>"; };
 		BFC1929727FC694A001455C1 /* PowerAuthSharingConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PowerAuthSharingConfiguration.m; sourceTree = "<group>"; };
+		BFFC5E062F6D6B5E00A1411B /* openssl.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = openssl.xcodeproj; path = "cc7/proj-xcode/openssl.xcodeproj"; sourceTree = "<group>"; };
+		BFFC5E142F7160FF00A1411B /* PA2ActivationStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2ActivationStatus.h; sourceTree = "<group>"; };
+		BFFC5E152F7160FF00A1411B /* PA2ActivationStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2ActivationStatus.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,6 +192,7 @@
 		BF86E805263C1DDF004C8AE5 = {
 			isa = PBXGroup;
 			children = (
+				BFFC5E062F6D6B5E00A1411B /* openssl.xcodeproj */,
 				BF86E81D263C1EBD004C8AE5 /* PowerAuth2ForWatch */,
 				BF86E810263C1DDF004C8AE5 /* Products */,
 			);
@@ -305,6 +321,8 @@
 				BF86E83B263C1EBD004C8AE5 /* PA2WCSessionPacket_Success.m */,
 				BF86E844263C1EBD004C8AE5 /* PA2WCSessionPacket_TokenData.h */,
 				BF86E837263C1EBD004C8AE5 /* PA2WCSessionPacket_TokenData.m */,
+				BFFC5E142F7160FF00A1411B /* PA2ActivationStatus.h */,
+				BFFC5E152F7160FF00A1411B /* PA2ActivationStatus.m */,
 			);
 			name = model;
 			sourceTree = "<group>";
@@ -316,6 +334,13 @@
 				BF86E852263C1EBE004C8AE5 /* Info.plist */,
 			);
 			name = support;
+			sourceTree = "<group>";
+		};
+		BFFC5E072F6D6B5E00A1411B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -333,6 +358,7 @@
 				BF86E8B8263C2512004C8AE5 /* PowerAuthDeprecated.h in Headers */,
 				BF1ED0AE2844C3FD00D6B380 /* PA2SimpleCancelable.h in Headers */,
 				BFC1929827FC694A001455C1 /* PowerAuthSharingConfiguration.h in Headers */,
+				BFFC5E172F7160FF00A1411B /* PA2ActivationStatus.h in Headers */,
 				BF86E870263C1EBE004C8AE5 /* PA2WCSessionPacket.h in Headers */,
 				BF86E87D263C1EBE004C8AE5 /* PowerAuthWCSessionManager+Private.h in Headers */,
 				BF86E8D6263C2BBF004C8AE5 /* PA2CoreCryptoUtils.h in Headers */,
@@ -376,6 +402,7 @@
 			buildConfigurationList = BF86E817263C1DDF004C8AE5 /* Build configuration list for PBXNativeTarget "PowerAuth2ForWatch" */;
 			buildPhases = (
 				BF86E80A263C1DDF004C8AE5 /* Headers */,
+				BFFC5E182F717E0900A1411B /* [CC7] XCFramework extract */,
 				BF86E80B263C1DDF004C8AE5 /* Sources */,
 				BF86E80C263C1DDF004C8AE5 /* Frameworks */,
 				BF86E80D263C1DDF004C8AE5 /* Resources */,
@@ -383,6 +410,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				BFFC5E0B2F6D85F200A1411B /* PBXTargetDependency */,
 			);
 			name = PowerAuth2ForWatch;
 			productName = PowerAuth2ForWatch;
@@ -404,7 +432,6 @@
 				};
 			};
 			buildConfigurationList = BF86E809263C1DDF004C8AE5 /* Build configuration list for PBXProject "PowerAuth2ForWatch" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -412,8 +439,16 @@
 				Base,
 			);
 			mainGroup = BF86E805263C1DDF004C8AE5;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = BF86E810263C1DDF004C8AE5 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = BFFC5E072F6D6B5E00A1411B /* Products */;
+					ProjectRef = BFFC5E062F6D6B5E00A1411B /* openssl.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				BF86E80E263C1DDF004C8AE5 /* PowerAuth2ForWatch */,
@@ -430,6 +465,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		BFFC5E182F717E0900A1411B /* [CC7] XCFramework extract */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[CC7] XCFramework extract";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Prepare platform / architecture specific framework\n\"${PROJECT_DIR}/cc7/openssl-build/xcbuild-helper.sh\" \"${EFFECTIVE_PLATFORM_NAME}\" \"${BUILT_PRODUCTS_DIR}\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		BF86E80B263C1DDF004C8AE5 /* Sources */ = {
@@ -459,6 +516,7 @@
 				BF86E865263C1EBE004C8AE5 /* PowerAuthWCSessionManager_WatchServices.m in Sources */,
 				BFC1929927FC694A001455C1 /* PowerAuthSharingConfiguration.m in Sources */,
 				BF86E871263C1EBE004C8AE5 /* PA2WCSessionPacket_Success.m in Sources */,
+				BFFC5E162F7160FF00A1411B /* PA2ActivationStatus.m in Sources */,
 				BF86E85B263C1EBE004C8AE5 /* PowerAuthErrorConstants.m in Sources */,
 				BF86E886263C1EBE004C8AE5 /* PowerAuthWCSessionManager.m in Sources */,
 				BF86E8B0263C231B004C8AE5 /* PowerAuthToken.m in Sources */,
@@ -470,6 +528,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		BFFC5E0B2F6D85F200A1411B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = OpenSSL;
+			targetProxy = BFFC5E0A2F6D85F200A1411B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		BF86E815263C1DDF004C8AE5 /* Debug */ = {
@@ -511,7 +577,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -528,11 +594,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/cc7/openssl-lib/apple/include";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/cc7/openssl-lib/apple/";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"-framework",
+					openssl,
+				);
 				SDKROOT = watchos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				TVOS_DEPLOYMENT_TARGET = 12.0;
@@ -581,7 +653,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -595,10 +667,16 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/cc7/openssl-lib/apple/include";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/cc7/openssl-lib/apple/";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = (
+					"-framework",
+					openssl,
+				);
 				SDKROOT = watchos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				TVOS_DEPLOYMENT_TARGET = 12.0;

--- a/Sources/PowerAuth2ForWatch/PowerAuthErrorConstants.h
+++ b/Sources/PowerAuth2ForWatch/PowerAuthErrorConstants.h
@@ -46,6 +46,9 @@ PA2_EXTERN_C NSString * __nonnull const PowerAuthErrorInfoKey_ResponseData;
  */
 PA2_EXTERN_C NSString * __nonnull const PowerAuthErrorInfoKey_ExternalPendingOperation;
 
+
+// TODO: redesign error codes
+
 /**
  Error codes returned for PowerAuthErrorDomain errors
  */
@@ -143,6 +146,26 @@ typedef NS_ENUM(NSInteger, PowerAuthErrorCode) {
      User canceled the biometric authentication dialog with a fallback button.
      */
     PowerAuthErrorCode_BiometryFallback             = 19,
+    /**
+     Failed to synchronize time with the server.
+     */
+    PowerAuthErrorCode_TimeSynchronization          = 20,
+    /**
+     Digital or JWS signature is not valid.
+     */
+    PowerAuthErrorCode_WrongSignature               = 21,
+    /**
+     Upgrade the PowerAuth Mobile SDK in your application. This error may occur if the local activation data was created
+     with a newer version of the SDK than the one currently used in your application.
+
+     This situation can happen if you downgraded your application during testing, or if you are using the activation
+     data sharing feature and another application upgraded the shared activation data to a newer format.
+     */
+    PowerAuthErrorCode_UpgradeSDK                   = 22,
+    /**
+     Other, unspecified error.
+     */
+    PowerAuthErrorCode_Other                        = 23,
 };
 
 @interface NSError (PowerAuthErrorCode)

--- a/Sources/PowerAuth2ForWatch/PowerAuthErrorConstants.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthErrorConstants.m
@@ -43,6 +43,7 @@ NSString * PA2MakeDefaultErrorDescription(NSInteger errorCode, NSString * messag
         _CODE_DESC(PowerAuthErrorCode_ActivationPending, @"Pending activation")
         _CODE_DESC(PowerAuthErrorCode_BiometryNotAvailable, @"Biometry is not supported or is unavailable")
         _CODE_DESC(PowerAuthErrorCode_BiometryCancel, @"User did cancel biometry authentication dialog")
+        _CODE_DESC(PowerAuthErrorCode_BiometryFallback, @"Used did press fallback at biometry authentication dialog")
         _CODE_DESC(PowerAuthErrorCode_BiometryFailed, @"Biometry authentication failed")
         _CODE_DESC(PowerAuthErrorCode_OperationCancelled, @"Operation was cancelled by SDK")
         _CODE_DESC(PowerAuthErrorCode_Encryption, @"General encryption failure")
@@ -50,8 +51,12 @@ NSString * PA2MakeDefaultErrorDescription(NSInteger errorCode, NSString * messag
         _CODE_DESC(PowerAuthErrorCode_InvalidToken, @"Invalid or unknown token")
         _CODE_DESC(PowerAuthErrorCode_WatchConnectivity, @"Watch connectivity error")
         _CODE_DESC(PowerAuthErrorCode_ProtocolUpgrade, @"Protocol upgrade error")
-        _CODE_DESC(PowerAuthErrorCode_PendingProtocolUpgrade, @"Pending protocol ugprade, try later")
+        _CODE_DESC(PowerAuthErrorCode_PendingProtocolUpgrade, @"Pending protocol upgrade, try later")
         _CODE_DESC(PowerAuthErrorCode_ExternalPendingOperation, @"Other application does critical operation")
+        _CODE_DESC(PowerAuthErrorCode_TimeSynchronization, @"Failed to synchronize time with the server")
+        _CODE_DESC(PowerAuthErrorCode_WrongSignature, @"Wrong digital signature")
+        _CODE_DESC(PowerAuthErrorCode_UpgradeSDK, @"PowerAuth Mobile SDK update is required")
+        _CODE_DESC(PowerAuthErrorCode_Other, @"Unspecified error")
         default:
             return [NSString stringWithFormat:@"Unknown error %@", @(errorCode)];
     }

--- a/Sources/PowerAuth2ForWatch/PowerAuthErrorConstants.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthErrorConstants.m
@@ -43,7 +43,7 @@ NSString * PA2MakeDefaultErrorDescription(NSInteger errorCode, NSString * messag
         _CODE_DESC(PowerAuthErrorCode_ActivationPending, @"Pending activation")
         _CODE_DESC(PowerAuthErrorCode_BiometryNotAvailable, @"Biometry is not supported or is unavailable")
         _CODE_DESC(PowerAuthErrorCode_BiometryCancel, @"User did cancel biometry authentication dialog")
-        _CODE_DESC(PowerAuthErrorCode_BiometryFallback, @"Used did press fallback at biometry authentication dialog")
+        _CODE_DESC(PowerAuthErrorCode_BiometryFallback, @"User did press fallback at biometry authentication dialog")
         _CODE_DESC(PowerAuthErrorCode_BiometryFailed, @"Biometry authentication failed")
         _CODE_DESC(PowerAuthErrorCode_OperationCancelled, @"Operation was cancelled by SDK")
         _CODE_DESC(PowerAuthErrorCode_Encryption, @"General encryption failure")

--- a/Sources/PowerAuth2ForWatch/PowerAuthMacros.h
+++ b/Sources/PowerAuth2ForWatch/PowerAuthMacros.h
@@ -85,6 +85,7 @@
     #define PA2_EXTERN_C_END
 #endif
 
+#define PA2_NO_EXPORT __attribute__((visibility("hidden")))
 
 #pragma mark - Apple platforms
 

--- a/Sources/PowerAuth2ForWatch/PowerAuthSessionStatusProvider.h
+++ b/Sources/PowerAuth2ForWatch/PowerAuthSessionStatusProvider.h
@@ -70,4 +70,14 @@
  */
 @property (nonatomic, strong, nullable, readonly) NSString *activationIdentifier;
 
+/**
+ Read only property contains the current PowerAuth algorithm used in the activation. If object has no valid activation, then contains nil.
+ */
+@property (nonatomic, strong, nullable, readonly) NSString *powerAuthAlgorithm;
+
+/**
+ Read only property contains the current PowerAuth protocol version used in the activation. If object has no valid activation, then contains nil.
+ */
+@property (nonatomic, strong, nullable, readonly) NSString *powerAuthProtocolVersion;
+
 @end

--- a/Sources/PowerAuth2ForWatch/PowerAuthToken.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthToken.m
@@ -128,7 +128,7 @@
                         @", token_digest=\"%@\""
                         @", nonce=\"%@\""
                         @", timestamp=\"%@\"",
-                        _version, tokenIdentifier, digestBase64, nonceBase64, currentTimeString];
+                        version, tokenIdentifier, digestBase64, nonceBase64, currentTimeString];
     return [PowerAuthAuthorizationHttpHeader tokenHeaderWithValue:value];
 }
 
@@ -164,8 +164,6 @@
     self = [super init];
     if (self) {
         _tokenStore = store;
-        _algorithm = store.algorithm;
-        _version = store.protocolVersion;
         _tokenData = data;
     }
     return self;

--- a/Sources/PowerAuth2ForWatch/PowerAuthToken.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthToken.m
@@ -24,18 +24,14 @@
 #import "PA2PrivateTokenInterfaces.h"
 #import "PA2PrivateTokenData.h"
 
-#if PA2_HAS_CORE_MODULE
-    // Regular SDK
-    @import PowerAuthCore;
-#else
-    // Extensions/watchOS SDK
-    #import "PA2CoreCryptoUtils.h"
-    #define PowerAuthCoreCryptoUtils PA2CoreCryptoUtils
-#endif
+// Extensions/watchOS SDK
+#import "PA2CoreCryptoUtils.h"
 
 @implementation PowerAuthToken
 {
     PA2PrivateTokenData * _tokenData;
+    NSString * _algorithm;
+    NSString * _version;
     __weak id<PowerAuthPrivateTokenStore> _tokenStore;
 }
 
@@ -70,9 +66,6 @@
 
 - (PowerAuthAuthorizationHttpHeader*) generateHeader
 {
-    NSData * tokenSecret = nil;
-    NSString * tokenIdentifier = nil;
-    
     if (!self.canGenerateHeader) {
 #if defined(DEBUG)
         if (!self.isValid) {
@@ -83,6 +76,8 @@
 #endif
         return nil;
     }
+    NSData * tokenSecret = nil;
+    NSString * tokenIdentifier = nil;
     
     tokenSecret = _tokenData.secret;
     tokenIdentifier = _tokenData.identifier;
@@ -91,30 +86,44 @@
     NSNumber * currentTimeMs = @((int64_t)([[NSDate date] timeIntervalSince1970] * 1000));
     NSString * currentTimeString = [currentTimeMs stringValue];
     NSData * currentTimeData = [currentTimeString dataUsingEncoding:NSASCIIStringEncoding];
-    NSData * nonce = [PowerAuthCoreCryptoUtils randomBytes:16];
-    if (nonce.length != 16) {
-        PowerAuthLog(@"PowerAuthToken: Random generator did not generate enough bytes.");
+    NSData * versionData = [_version dataUsingEncoding:NSASCIIStringEncoding];
+    NSData * nonce = [PA2CoreCryptoUtils randomBytes:16];
+    if (!nonce) {
+        PowerAuthLog(@"PowerAuthToken: Failed to generate nonce.");
         return nil;
     }
     NSMutableData * data = [nonce mutableCopy];
     [data appendBytes:"&" length:1];
-    [data appendData: currentTimeData];
+    [data appendData:currentTimeData];
+    [data appendBytes:"&" length:1];
+    [data appendData:versionData];
+    
     // Calculate digest...
-    NSData * digest = [PowerAuthCoreCryptoUtils hmacSha256:data key:tokenSecret];
-    NSString * digestBase64 = [digest base64EncodedStringWithOptions:0];
-    NSString * nonceBase64 = [nonce base64EncodedStringWithOptions:0];
-    // Final check...
-    if (digest.length == 0 || !digestBase64 || !nonceBase64 || !currentTimeString) {
+    NSData * digest;
+    if ([@"LEGACY_P256" isEqualToString:_algorithm]) {
+        // V3
+        digest = [PA2CoreCryptoUtils hmacSha256:data
+                                            key:tokenSecret];
+    } else {
+        // V4
+        digest = [PA2CoreCryptoUtils kmac256:data
+                                         key:tokenSecret
+                                      custom:[@"PA4DIGEST" dataUsingEncoding:NSASCIIStringEncoding]
+                                        size:32];
+    }
+    if (!digest) {
         PowerAuthLog(@"PowerAuthToken: Digest calculation did fail.");
         return nil;
     }
+    NSString * digestBase64 = [digest base64EncodedStringWithOptions:0];
+    NSString * nonceBase64 = [nonce base64EncodedStringWithOptions:0];
     NSString * value = [NSString stringWithFormat:
-                        @"PowerAuth version=\"3.1\""
+                        @"PowerAuth version=\"%@\""
                         @", token_id=\"%@\""
                         @", token_digest=\"%@\""
                         @", nonce=\"%@\""
                         @", timestamp=\"%@\"",
-                        tokenIdentifier, digestBase64, nonceBase64, currentTimeString];
+                        _version, tokenIdentifier, digestBase64, nonceBase64, currentTimeString];
     return [PowerAuthAuthorizationHttpHeader tokenHeaderWithValue:value];
 }
 
@@ -133,7 +142,8 @@
 
 - (id) copyWithZone:(NSZone *)zone
 {
-    return [[PowerAuthToken alloc] initWithStore:_tokenStore data:[_tokenData copy]];
+    return [[PowerAuthToken alloc] initWithStore:_tokenStore
+                                            data:[_tokenData copy]];
 }
 
 #pragma mark - Private methods
@@ -149,6 +159,8 @@
     self = [super init];
     if (self) {
         _tokenStore = store;
+        _algorithm = store.algorithm;
+        _version = store.protocolVersion;
         _tokenData = data;
     }
     return self;

--- a/Sources/PowerAuth2ForWatch/PowerAuthToken.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthToken.m
@@ -30,8 +30,6 @@
 @implementation PowerAuthToken
 {
     PA2PrivateTokenData * _tokenData;
-    NSString * _algorithm;
-    NSString * _version;
     __weak id<PowerAuthPrivateTokenStore> _tokenStore;
 }
 
@@ -76,6 +74,13 @@
 #endif
         return nil;
     }
+    NSString * version = _tokenStore.protocolVersion;
+    NSString * algorithm = _tokenStore.algorithm;
+    if (!version || !algorithm) {
+        PowerAuthLog(@"PowerAuthToken: Protocol version or algorithm is unknown.");
+        return nil;
+    }
+
     NSData * tokenSecret = nil;
     NSString * tokenIdentifier = nil;
     
@@ -86,7 +91,7 @@
     NSNumber * currentTimeMs = @((int64_t)([[NSDate date] timeIntervalSince1970] * 1000));
     NSString * currentTimeString = [currentTimeMs stringValue];
     NSData * currentTimeData = [currentTimeString dataUsingEncoding:NSASCIIStringEncoding];
-    NSData * versionData = [_version dataUsingEncoding:NSASCIIStringEncoding];
+    NSData * versionData = [version dataUsingEncoding:NSASCIIStringEncoding];
     NSData * nonce = [PA2CoreCryptoUtils randomBytes:16];
     if (!nonce) {
         PowerAuthLog(@"PowerAuthToken: Failed to generate nonce.");
@@ -100,7 +105,7 @@
     
     // Calculate digest...
     NSData * digest;
-    if ([@"LEGACY_P256" isEqualToString:_algorithm]) {
+    if ([@"LEGACY_P256" isEqualToString:algorithm]) {
         // V3
         digest = [PA2CoreCryptoUtils hmacSha256:data
                                             key:tokenSecret];

--- a/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.h
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.h
@@ -49,7 +49,7 @@
  Processes a received message data and returns YES if message has been consumed (e.g. PowerAuth
  is the data recipient), NO otherwise. If YES is returned and the replyHandler is available, then the handler
  is called with a valid reply data. The replyHandler nullability must match behavior of the message. That means
- that if WCSessionDelegate method is called with a valid reply handler (e.g. counterpart is expecing response),
+ that if WCSessionDelegate method is called with a valid reply handler (e.g. counterpart is expecting response),
  then you have to always provide the reply handler to this method.
  */
 - (BOOL) processReceivedMessageData:(nonnull NSData *)data

--- a/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
@@ -75,7 +75,7 @@ static WCSession * _ValidateSession(WCSession * session);
 #pragma mark - Thread safety
 
 /**
- Prepares runtime data required by this class. We're initializing that objects only
+ Prepares runtime data required by this class. We're initializing those objects only
  on demand, when the first token is being accessed.
  */
 static void _prepareInstance(PowerAuthWCSessionManager * obj)
@@ -121,57 +121,65 @@ static const char  _HeaderVersion = '2';
 #define _MagicSize   sizeof(_HeaderMagic)
 #define _HeaderSize  (_MagicSize + 1)
 
-static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass, BOOL *unknownData)
+static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass, BOOL* failure)
 {
     // Validate minimal length of data
     if (data.length < _HeaderSize + 12) {
-        *unknownData = YES;
+        *failure = NO;
         return nil;
     }
     // ... and the magic constant at the beginning
     const char * dataBytes = data.bytes;
     if (memcmp(dataBytes, _HeaderMagic, _MagicSize)) {
-        *unknownData = YES;
+        *failure = NO;
         return nil;
     }
     
     // We can process the response after this point.
-    *unknownData = NO;
     
     // Compare versions
     if (dataBytes[_MagicSize] != _HeaderVersion) {
         // Reply with a special packet with identical version as we received. This guarantees that another side is able to process this error.
+        *failure = YES;
         NSString * message = @"PA2WCSessionManager: PowerAuth Mobile SDK and Watch SDK are not compatible.";
         PA2WCSessionPacket * packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
         packet.customPacketVersion = dataBytes[_MagicSize];
         return packet;
     }
     
-    // ... the rest of data contains valid JSON
-    NSData * JSONData = [data subdataWithRange:NSMakeRange(_HeaderSize, data.length - _HeaderSize)];
-    NSDictionary * JSON = PA2ObjectAs([NSJSONSerialization JSONObjectWithData:JSONData options:0 error:NULL], NSDictionary);
-    PA2WCSessionPacket * packet;
-    if (JSON) {
-        packet = [[PA2WCSessionPacket alloc] initWithDictionary:JSON];
-        if (packet && payloadClass != Nil && !packet.error) {
+    // ... the rest of data should contain valid JSON
+    NSData * jsonData = [data subdataWithRange:NSMakeRange(_HeaderSize, data.length - _HeaderSize)];
+    NSError * error = nil;
+    NSDictionary * root = PA2ObjectAs([NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error], NSDictionary);
+    if (!root) {
+        *failure = YES;
+        return [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Invalid payload. Failed to deserialize JSON.")];
+    }
+    // Construct packet for further investigation
+    PA2WCSessionPacket * packet = [[PA2WCSessionPacket alloc] initWithDictionary:root];
+    if (packet) {
+        if (payloadClass != Nil && !packet.error) {
             // Process payload only when class is known and there's no error in the packet.
             if ([payloadClass conformsToProtocol:@protocol(PA2WCSessionPacketData)]) {
-                id<PA2WCSessionPacketData> payload = [[payloadClass alloc] initWithDictionary:JSON];
+                id<PA2WCSessionPacketData> payload = [[payloadClass alloc] initWithDictionary:root];
                 if ([payload validatePacketData]) {
                     packet.payload = payload;
                 } else {
                     NSString * message = [NSString stringWithFormat:@"PA2WCSessionManager: Invalid payload. %@ class is expected.", NSStringFromClass(payloadClass)];
-                    packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
+                    error = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message);
                 }
             } else {
-                NSString * message = @"PA2WCSessionManager: Invalid class provided for payload response.";
-                packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
+                error = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Invalid class provided for payload response.");
             }
         }
     } else {
-        NSString * message = @"PA2WCSessionManager: Invalid payload. Failed to deserialize JSON.";
-        packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
+        error = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Invalid packet received.");
     }
+    if (error) {
+        *failure = YES;
+        return [PA2WCSessionPacket packetWithError:error];
+    }
+    *failure = NO;
     return packet;
 }
 
@@ -179,12 +187,12 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 {
     NSDictionary * dict = [packet toDictionary];
     if (!dict) {
-        PowerAuthLog(@"PA2WCSessionManager: Cannon serialize packet to dictionary.");
+        PowerAuthLog(@"PA2WCSessionManager: Cannot serialize packet to dictionary.");
         return nil;
     }
     NSData * JSONData = [NSJSONSerialization dataWithJSONObject:dict options:0 error:NULL];
     if (!JSONData) {
-        PowerAuthLog(@"PA2WCSessionManager: Cannon serialize packet to JSON.");
+        PowerAuthLog(@"PA2WCSessionManager: Cannot serialize packet to JSON.");
         return nil;
     }
     // Prepare the packet version. If not set, then use the default version.
@@ -208,16 +216,16 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
     PA2WCSessionPacket * response = nil;
     NSString * errorMessage = nil;
     do {
-        BOOL unknownData;
-        PA2WCSessionPacket * packet = _DeserializePacket(data, Nil, &unknownData);
+        BOOL failure;
+        PA2WCSessionPacket * packet = _DeserializePacket(data, Nil, &failure);
         if (!packet) {
-            if (unknownData) {
-                // Quick return, we don't understand this data
-                return NO;
-            }
-            // Data looks targetting us, but cannot be decoded.
-            // Check whether PowerAuth2 & PowerAuth2ForWatch versions match.
-            errorMessage = @"PA2WCSessionManager: Wrong packet received.";
+            // Quick return, we don't understand this data
+            return NO;
+        }
+        if (failure) {
+            // Incoming packet processing raised an error. This is already the response.
+            response = packet;
+            errorMessage = response.error.localizedDescription;
             break;
         }
         //
@@ -332,15 +340,6 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
     [self sendImpl:packet withResponse:YES responseClass:responseClass completion:completion];
 }
 
-
-// Unguarded availability warning
-//
-// We're targetting SDK to 8.0+, so it's expected that compiler will scream about
-// usage of WCSession, which is available sice 9.0. The problematic part of code
-// begins when we acquire WCSession from self.validSession but we can ignore that,
-// because that property already checks whether the session is available on the
-// current system.
-
 - (void) sendImpl:(PA2WCSessionPacket*)request
      withResponse:(BOOL)withResponse
     responseClass:(Class)responseClass
@@ -371,7 +370,7 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
     // Get a valid session
     WCSession * session = self.validSession;
     if (!session) {
-        // On IOS, switch to debug build and check log what's the reason of unavailability.
+        // On iOS, switch to debug build and check the log for the reason of unavailability.
         // On watchOS, the session is typically not activated
         PowerAuthLog(@"PA2WCSessionManager: WCSession is currently not available for messaging.");
         if (completion) {
@@ -387,15 +386,11 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
         if (sessionIsReachable) {
             [session sendMessageData:requestData replyHandler:^(NSData * replyMessageData) {
                 //
-                BOOL unknownData = YES;
-                PA2WCSessionPacket * responsePacket = _DeserializePacket(replyMessageData, responseClass, &unknownData);
+                BOOL failure;
+                PA2WCSessionPacket * responsePacket = _DeserializePacket(replyMessageData, responseClass, &failure);
                 NSError * responseError = responsePacket.error;
                 if (!responsePacket) {
-                    if (unknownData) {
-                        responseError = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Received response is in unknown data format.");
-                    } else {
-                        responseError = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Cannot process received response.");
-                    }
+                    responseError = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WCSessionManager: Received response is in unknown data format.");
                 }
                 if (responseError) {
                     responsePacket = nil;
@@ -449,7 +444,7 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 
 static WCSession * _PrepareSession(void)
 {
-    // On watcOS, we can always return defaultSession.
+    // On watchOS, we can always return defaultSession.
     return [WCSession defaultSession];
 }
 

--- a/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
@@ -30,18 +30,6 @@
 #import "PA2WCSessionPacket.h"
 #import "PA2WeakArray.h"
 
-// Unguarded availability warning
-//
-// PA2WCSessionManager is correctly handling existence of WCSession on the system,
-// but it's difficult to wrap all parts of the code to silent the warning.
-// Currently, 'sendImpl' is the most problematic part of the code, so check
-// that method for details (there's comment at the beginning of the method)
-//
-// For future, we need to increase minimum supported version to iOS9.0
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-
 @implementation PowerAuthWCSessionManager
 {
     dispatch_semaphore_t _lock;
@@ -128,8 +116,10 @@ static void _synchronizedVoid(PowerAuthWCSessionManager  * obj, void(^block)(voi
 
 #pragma mark - Helper functions
 
-static const unsigned char  _HeaderMagic[] = { 'P', 'A', 'w', 'c', '1' };
-#define _HeaderSize sizeof(_HeaderMagic)
+static const char  _HeaderMagic[] = { 'P', 'A', 'w', 'c' };
+static const char  _HeaderVersion = '2';
+#define _MagicSize   sizeof(_HeaderMagic)
+#define _HeaderSize  (_MagicSize + 1)
 
 static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass, BOOL *unknownData)
 {
@@ -139,9 +129,19 @@ static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass
         return nil;
     }
     // ... and the magic constant at the beginning
-    if (memcmp(data.bytes, _HeaderMagic, _HeaderSize)) {
+    const char * dataBytes = data.bytes;
+    if (memcmp(dataBytes, _HeaderMagic, _MagicSize)) {
         *unknownData = YES;
         return nil;
+    }
+    
+    // Compare versions
+    if (dataBytes[_MagicSize] != _HeaderVersion) {
+        // Reply with a special packet with identical version as we received. This guarantees that another side is able to process this error.
+        NSString * message = @"PA2WCSessionManager: PowerAuth Mobile SDK and Watch SDK are not compatible.";
+        PA2WCSessionPacket * packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
+        packet.customPacketVersion = dataBytes[_MagicSize];
+        return packet;
     }
     
     // ... and if the rest of data contains valid JSON
@@ -182,8 +182,14 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
         PowerAuthLog(@"PA2WCSessionManager: Cannon serialize packet to JSON.");
         return nil;
     }
+    // Prepare the packet version. If not set, then use the default version.
+    char packetVersion = packet.customPacketVersion;
+    if (!packetVersion) {
+        packetVersion = _HeaderVersion;
+    }
     NSMutableData * data = [NSMutableData dataWithCapacity:_HeaderSize + JSONData.length];
-    [data appendBytes:_HeaderMagic length:_HeaderSize];
+    [data appendBytes:_HeaderMagic length:_MagicSize];
+    [data appendBytes:&packetVersion length:1];
     [data appendData:JSONData];
     return data;
 }
@@ -212,7 +218,7 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
         //
         NSString * target = packet.target;
         if ([target isEqualToString:PA2WCSessionPacket_RESPONSE_TARGET]) {
-            errorMessage = @"PA2WCSessionManager: Requests with reponse target are not allowed.";
+            errorMessage = @"PA2WCSessionManager: Requests with response target are not allowed.";
             break;
         }
         // Look for handler
@@ -491,8 +497,6 @@ static WCSession * _ValidateSession(WCSession * session)
 }
 
 #endif // !defined(PA2_WATCH_SDK)
-
-#pragma clang diagnostic pop    // pop "-Wunguarded-availability"
 
 // -----------------------------------------------------------------------
 #endif // defined(PA2_WATCH_SUPPORT)

--- a/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
@@ -135,6 +135,9 @@ static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass
         return nil;
     }
     
+    // We can process the response after this point.
+    *unknownData = NO;
+    
     // Compare versions
     if (dataBytes[_MagicSize] != _HeaderVersion) {
         // Reply with a special packet with identical version as we received. This guarantees that another side is able to process this error.
@@ -144,28 +147,30 @@ static PA2WCSessionPacket * _DeserializePacket(NSData * data, Class payloadClass
         return packet;
     }
     
-    // ... and if the rest of data contains valid JSON
-    *unknownData = NO;
+    // ... the rest of data contains valid JSON
     NSData * JSONData = [data subdataWithRange:NSMakeRange(_HeaderSize, data.length - _HeaderSize)];
     NSDictionary * JSON = PA2ObjectAs([NSJSONSerialization JSONObjectWithData:JSONData options:0 error:NULL], NSDictionary);
-    if (!JSON) {
-        return nil;
-    }
-    PA2WCSessionPacket * packet = [[PA2WCSessionPacket alloc] initWithDictionary:JSON];
-    if (packet && payloadClass != Nil && !packet.error) {
-        // Process payload only when class is known and there's no error in the packet.
-        if ([payloadClass conformsToProtocol:@protocol(PA2WCSessionPacketData)]) {
-            id<PA2WCSessionPacketData> payload = [[payloadClass alloc] initWithDictionary:JSON];
-            if ([payload validatePacketData]) {
-                packet.payload = payload;
+    PA2WCSessionPacket * packet;
+    if (JSON) {
+        packet = [[PA2WCSessionPacket alloc] initWithDictionary:JSON];
+        if (packet && payloadClass != Nil && !packet.error) {
+            // Process payload only when class is known and there's no error in the packet.
+            if ([payloadClass conformsToProtocol:@protocol(PA2WCSessionPacketData)]) {
+                id<PA2WCSessionPacketData> payload = [[payloadClass alloc] initWithDictionary:JSON];
+                if ([payload validatePacketData]) {
+                    packet.payload = payload;
+                } else {
+                    NSString * message = [NSString stringWithFormat:@"PA2WCSessionManager: Invalid payload. %@ class is expected.", NSStringFromClass(payloadClass)];
+                    packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
+                }
             } else {
-                NSString * message = [NSString stringWithFormat:@"PA2WCSessionManager: Invalid payload. %@ class is expected.", NSStringFromClass(payloadClass)];
+                NSString * message = @"PA2WCSessionManager: Invalid class provided for payload response.";
                 packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
             }
-        } else {
-            NSString * message = @"PA2WCSessionManager: Invalid class provided for payload response.";
-            packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
         }
+    } else {
+        NSString * message = @"PA2WCSessionManager: Invalid payload. Failed to deserialize JSON.";
+        packet = [PA2WCSessionPacket packetWithError:PA2MakeError(PowerAuthErrorCode_WatchConnectivity, message)];
     }
     return packet;
 }

--- a/Sources/PowerAuth2ForWatch/PowerAuthWatchSDK.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWatchSDK.m
@@ -83,6 +83,16 @@
     return [[PA2WatchSynchronizationService sharedInstance] activationIdForSessionInstanceId:_configuration.instanceId];
 }
 
+- (NSString*) powerAuthAlgorithm
+{
+    return [[PA2WatchSynchronizationService sharedInstance] activationStatusForSessionInstanceId:_configuration.instanceId].algorithm;
+}
+
+- (NSString*) powerAuthProtocolVersion
+{
+    return [[PA2WatchSynchronizationService sharedInstance] activationStatusForSessionInstanceId:_configuration.instanceId].protocolVersion;
+}
+
 - (id<PowerAuthTokenStore>) tokenStore
 {
     return _tokenStore;
@@ -164,8 +174,7 @@
             BOOL invalidPacket = YES;
             if ([status validatePacketData]) {
                 if ([status.command isEqualToString:PA2WCSessionPacket_CMD_SESSION_PUT]) {
-                    activationId = status.activationId;
-                    [[PA2WatchSynchronizationService sharedInstance] updateActivationId:activationId forSessionInstanceId:_configuration.instanceId];
+                    [[PA2WatchSynchronizationService sharedInstance] updateActivationStatus:status forSessionInstanceId:_configuration.instanceId];
                     invalidPacket = NO;
                 }
             }

--- a/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2WCSessionPacket_ActivationStatus.h"
+
+/// The `PA2ActivationStatus` class contains activation data stored in the keychain.
+@interface PA2ActivationStatus : NSObject
+
+@property (nonatomic, readonly) NSUInteger dataVersion;
+@property (nonatomic, strong, readonly, nullable) NSString * activationId;
+@property (nonatomic, strong, readonly, nullable) NSString * protocolVersion;
+@property (nonatomic, strong, readonly, nullable) NSString * algorithm;
+
+/// Serialize object to data.
+- (nonnull NSData*) toData;
+
+/// Deserialize object from data.
+/// - Parameter data: Previously serialized data.
++ (nonnull PA2ActivationStatus*) fromData:(nullable NSData*)data;
+
+/// Create object from received status packet. If `nil` is provided, then creates an empty object.
+/// - Parameter status: Received status packet.
++ (nonnull PA2ActivationStatus*) fromPacket:(nullable PA2WCSessionPacket_ActivationStatus*)status;
+
+- (BOOL) isEqual:(nullable id)object;
+
+@end
+

--- a/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.h
@@ -36,6 +36,7 @@
 + (nonnull PA2ActivationStatus*) fromPacket:(nullable PA2WCSessionPacket_ActivationStatus*)status;
 
 - (BOOL) isEqual:(nullable id)object;
+- (NSUInteger) hash;
 
 @end
 

--- a/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.h
@@ -27,13 +27,15 @@
 /// Serialize object to data.
 - (nonnull NSData*) toData;
 
-/// Deserialize object from data.
+/// Deserialize object from previously serialized data.
 /// - Parameter data: Previously serialized data.
-+ (nonnull PA2ActivationStatus*) fromData:(nullable NSData*)data;
+/// - Returns: Status object created from the received packet, or `nil` if input data is `nil` or if deserialized data is invalid.
++ (nullable PA2ActivationStatus*) fromData:(nullable NSData*)data;
 
-/// Create object from received status packet. If `nil` is provided, then creates an empty object.
+/// Create object from received status packet.
 /// - Parameter status: Received status packet.
-+ (nonnull PA2ActivationStatus*) fromPacket:(nullable PA2WCSessionPacket_ActivationStatus*)status;
+/// - Returns: Status object created from the received packet, or `nil` if received packet is `nil`.
++ (nullable PA2ActivationStatus*) fromPacket:(nullable PA2WCSessionPacket_ActivationStatus*)status;
 
 - (BOOL) isEqual:(nullable id)object;
 - (NSUInteger) hash;

--- a/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.m
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2ActivationStatus.h"
+#import "PA2PrivateMacros.h"
+
+#import <PowerAuth2ForWatch/PowerAuthLog.h>
+
+static const NSUInteger DATA_VER = 1;
+
+static NSString * const KEY_DATA_VER        = @"ver";
+static NSString * const KEY_PROTOCOL        = @"pro";
+static NSString * const KEY_ALGORITHM       = @"alg";
+static NSString * const KEY_ACTIVATION_ID   = @"aid";
+
+static NSString * const FALLBACK_ALGORITHM  = @"LEGACY_P256";
+static NSString * const FALLBACK_PROTOCOL   = @"3.3";
+
+@implementation PA2ActivationStatus
+
+- (instancetype) init
+{
+    self = [super init];
+    if (self) {
+        _dataVersion = DATA_VER;
+    }
+    return self;
+}
+
+- (instancetype) initWithDataVersion:(NSUInteger)dataVersion
+                        activationId:(NSString*)activationId
+                           algorithm:(NSString*)algorithm
+                            protocol:(NSString*)protocol
+{
+    self = [super init];
+    if (self) {
+        _dataVersion = dataVersion;
+        _activationId = activationId;
+        _algorithm = algorithm;
+        _protocolVersion = protocol;
+    }
+    return self;
+}
+
+- (NSData*) toData
+{
+    NSMutableDictionary * dict = [NSMutableDictionary dictionaryWithCapacity:4];
+    dict[KEY_DATA_VER] = @(_dataVersion);
+    if (_protocolVersion) {
+        dict[KEY_PROTOCOL] = _protocolVersion;
+    }
+    if (_algorithm) {
+        dict[KEY_ALGORITHM] = _algorithm;
+    }
+    if (_activationId) {
+        dict[KEY_ACTIVATION_ID] = _activationId;
+    }
+    return [NSJSONSerialization dataWithJSONObject:dict options:0 error:NULL];
+}
+
++ (instancetype) fromData:(NSData*)data
+{
+    if (data) {
+        NSString * stringRepr = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        if (stringRepr) {
+            if ([stringRepr hasPrefix:@"{"]) {
+                // New "JSON" format
+                NSError * error = nil;
+                id jsonRepr = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+                if (jsonRepr && !error) {
+                    NSDictionary * dict = PA2ObjectAs(jsonRepr, NSDictionary);
+                    if (dict) {
+                        NSUInteger dataVersion = [PA2ObjectAs(dict[KEY_DATA_VER], NSNumber) unsignedIntegerValue];
+                        NSString * activationId = PA2ObjectAs(dict[KEY_ACTIVATION_ID], NSString);
+                        NSString * protocolVer = PA2ObjectAs(dict[KEY_PROTOCOL], NSString);
+                        NSString * algorithm = PA2ObjectAs(dict[KEY_ALGORITHM], NSString);
+                        if (dataVersion == DATA_VER) {
+                            return [[PA2ActivationStatus alloc] initWithDataVersion:dataVersion
+                                                                       activationId:activationId
+                                                                          algorithm:algorithm
+                                                                           protocol:protocolVer];
+                        }
+                        PowerAuthLog(@"PA2ActivationStatus: Unsupported data version");
+                    } else {
+                        PowerAuthLog(@"PA2ActivationStatus: Deserialized object is not dictionary");
+                    }
+                } else {
+                    PowerAuthLog(@"PA2ActivationStatus: Failed to deserialize activation status: %@", error);
+                }
+            } else {
+                // Legacy format, when only activation ID was serialized
+                return [[PA2ActivationStatus alloc] initWithDataVersion:DATA_VER
+                                                           activationId:stringRepr
+                                                              algorithm:FALLBACK_ALGORITHM
+                                                               protocol:FALLBACK_PROTOCOL];
+            }
+        }
+    }
+    return [[PA2ActivationStatus alloc] init];
+    
+}
+
++ (instancetype) fromPacket:(PA2WCSessionPacket_ActivationStatus*)status
+{
+    if (status) {
+        return [[PA2ActivationStatus alloc] initWithDataVersion:DATA_VER
+                                                   activationId:status.activationId
+                                                      algorithm:status.algorithm
+                                                       protocol:status.protocolVersion];
+    }
+    return [[PA2ActivationStatus alloc] init];
+}
+
+- (BOOL) isEqual:(id)object
+{
+    if (object == self) {
+        // Same instance
+        return YES;
+    }
+    PA2ActivationStatus * other = PA2ObjectAs(object, PA2ActivationStatus);
+    if (!other) {
+        // Different object type
+        return NO;
+    }
+    return _dataVersion == other->_dataVersion &&
+            [_activationId isEqualToString:other->_activationId] &&
+            [_algorithm isEqualToString:other->_algorithm] &&
+            [_protocolVersion isEqualToString:other->_protocolVersion];
+}
+
+@end

--- a/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.m
@@ -109,7 +109,7 @@ static NSString * const FALLBACK_PROTOCOL   = @"3.3";
             }
         }
     }
-    return [[PA2ActivationStatus alloc] init];
+    return nil;
     
 }
 
@@ -121,7 +121,7 @@ static NSString * const FALLBACK_PROTOCOL   = @"3.3";
                                                       algorithm:status.algorithm
                                                        protocol:status.protocolVersion];
     }
-    return [[PA2ActivationStatus alloc] init];
+    return nil;
 }
 
 static BOOL _StringCompare(NSString * s1, NSString * s2)

--- a/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2ActivationStatus.m
@@ -124,6 +124,14 @@ static NSString * const FALLBACK_PROTOCOL   = @"3.3";
     return [[PA2ActivationStatus alloc] init];
 }
 
+static BOOL _StringCompare(NSString * s1, NSString * s2)
+{
+    if (s1 == s2) {
+        return YES;
+    }
+    return [s1 isEqualToString:s2];
+}
+
 - (BOOL) isEqual:(id)object
 {
     if (object == self) {
@@ -136,9 +144,18 @@ static NSString * const FALLBACK_PROTOCOL   = @"3.3";
         return NO;
     }
     return _dataVersion == other->_dataVersion &&
-            [_activationId isEqualToString:other->_activationId] &&
-            [_algorithm isEqualToString:other->_algorithm] &&
-            [_protocolVersion isEqualToString:other->_protocolVersion];
+            _StringCompare(_activationId, other->_activationId) &&
+            _StringCompare(_algorithm, other->_algorithm) &&
+            _StringCompare(_protocolVersion, other->_protocolVersion);
+}
+
+- (NSUInteger) hash
+{
+    NSUInteger hash = _dataVersion;
+    hash = hash * 31u + _activationId.hash;
+    hash = hash * 31u + _algorithm.hash;
+    hash = hash * 31u + _protocolVersion.hash;
+    return hash;
 }
 
 @end

--- a/Sources/PowerAuth2ForWatch/private/PA2CoreCryptoUtils.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2CoreCryptoUtils.h
@@ -29,13 +29,26 @@
 /**
  Computes SHA-256 from given data.
  */
-+ (nonnull NSData*) hashSha256:(nonnull NSData*)data;
++ (nullable NSData*) hashSha256:(nullable NSData*)data;
+
+/**
+ Computes SHA3-256 from given data.
+ */
++ (nullable NSData*) hashSha3_256:(nullable NSData*)data;
 
 /**
  Computes HMAC-SHA-256 for given data and key.
  */
-+ (nonnull NSData*) hmacSha256:(nonnull NSData*)data
-                           key:(nonnull NSData*)key;
++ (nullable NSData*) hmacSha256:(nullable NSData*)data
+                            key:(nonnull NSData*)key;
+
+/**
+ Computes KMAC-256 for given data and key.
+ **/
++ (nullable NSData*) kmac256:(nullable NSData*)data
+                         key:(nonnull NSData*)key
+                      custom:(nonnull NSData*)custom
+                        size:(NSUInteger)size;
 
 /**
  Generates a required amount of random bytes. Returns nil in case that

--- a/Sources/PowerAuth2ForWatch/private/PA2CoreCryptoUtils.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2CoreCryptoUtils.m
@@ -30,14 +30,23 @@
 static NSData * _CalculateHash(NSData * data, const EVP_MD * md, size_t out_size)
 {
     NSMutableData * hash = [NSMutableData dataWithLength:out_size];
-    EVP_MD_CTX * ctx = EVP_MD_CTX_new();
+    EVP_MD_CTX * ctx;
     BOOL success = NO;
     do {
-        EVP_DigestInit(ctx, md);
-        if (data) {
-            EVP_DigestUpdate(ctx, data.bytes, data.length);
+        if (!(ctx = EVP_MD_CTX_new())) {
+            break;
         }
-        EVP_DigestFinal(ctx, hash.mutableBytes, NULL);
+        if (1 != EVP_DigestInit(ctx, md)) {
+            break;
+        }
+        if (data) {
+            if (1 != EVP_DigestUpdate(ctx, data.bytes, data.length)) {
+                break;
+            }
+        }
+        if (1 != EVP_DigestFinal(ctx, hash.mutableBytes, NULL)) {
+            break;
+        }
         success = YES;
     } while (false);
     if (ctx) EVP_MD_CTX_free(ctx);

--- a/Sources/PowerAuth2ForWatch/private/PA2CoreCryptoUtils.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2CoreCryptoUtils.m
@@ -30,7 +30,7 @@
 static NSData * _CalculateHash(NSData * data, const EVP_MD * md, size_t out_size)
 {
     NSMutableData * hash = [NSMutableData dataWithLength:out_size];
-    EVP_MD_CTX * ctx;
+    EVP_MD_CTX * ctx = NULL;
     BOOL success = NO;
     do {
         if (!(ctx = EVP_MD_CTX_new())) {
@@ -59,7 +59,7 @@ static NSData * _CalculateMac(NSData * data, NSData * key, NSData * custom,
 {
     BOOL success = NO;
     NSMutableData * result = [NSMutableData dataWithLength:out_size];
-    EVP_MAC * mac;
+    EVP_MAC * mac = NULL;
     EVP_MAC_CTX * ctx = NULL;
     OSSL_PARAM_BLD * builder = NULL;
     OSSL_PARAM * params = NULL;

--- a/Sources/PowerAuth2ForWatch/private/PA2CoreCryptoUtils.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2CoreCryptoUtils.m
@@ -20,24 +20,107 @@
 #import "PA2CoreCryptoUtils.h"
 #import <PowerAuth2ForWatch/PowerAuthLog.h>
 
-#include <CommonCrypto/CommonCrypto.h>
-#include <CommonCrypto/CommonRandom.h>
+#include <openssl/evp.h>
+#include <openssl/param_build.h>
+#include <openssl/core_names.h>
+#include <openssl/rand.h>
 
 @implementation PA2CoreCryptoUtils
 
-+ (nonnull NSData*) hashSha256:(nonnull NSData*)data
+static NSData * _CalculateHash(NSData * data, const EVP_MD * md, size_t out_size)
 {
-    unsigned char md[CC_SHA256_DIGEST_LENGTH];
-    CC_SHA256(data.bytes, (CC_LONG)data.length, md);
-    return [NSData dataWithBytes:md length:sizeof(md)];
+    NSMutableData * hash = [NSMutableData dataWithLength:out_size];
+    EVP_MD_CTX * ctx = EVP_MD_CTX_new();
+    BOOL success = NO;
+    do {
+        EVP_DigestInit(ctx, md);
+        if (data) {
+            EVP_DigestUpdate(ctx, data.bytes, data.length);
+        }
+        EVP_DigestFinal(ctx, hash.mutableBytes, NULL);
+        success = YES;
+    } while (false);
+    if (ctx) EVP_MD_CTX_free(ctx);
+    return success ? hash : nil;
 }
 
-+ (nonnull NSData*) hmacSha256:(nonnull NSData*)data
-                           key:(nonnull NSData*)key
+static NSData * _CalculateMac(NSData * data, NSData * key, NSData * custom,
+                              const char * alg, const char * md,
+                              size_t out_size)
 {
-    char mac[CC_SHA256_DIGEST_LENGTH];
-    CCHmac(kCCHmacAlgSHA256, key.bytes, key.length, data.bytes, data.length, mac);
-    return [NSData dataWithBytes:mac length:sizeof(mac)];
+    BOOL success = NO;
+    NSMutableData * result = [NSMutableData dataWithLength:out_size];
+    EVP_MAC * mac;
+    EVP_MAC_CTX * ctx = NULL;
+    OSSL_PARAM_BLD * builder = NULL;
+    OSSL_PARAM * params = NULL;
+    do {
+        // Fetch MAC & prepare CTX object
+        if (!(mac = EVP_MAC_fetch(NULL, alg, NULL))) {
+            break;
+        }
+        if (!(ctx = EVP_MAC_CTX_new(mac))) {
+            break;
+        }
+        // Parametrize MAC with params builder
+        if (!(builder = OSSL_PARAM_BLD_new())) {
+            break;
+        }
+        if (md) {
+            OSSL_PARAM_BLD_push_utf8_string(builder, OSSL_MAC_PARAM_DIGEST,
+                                            md, strlen(md));
+        }
+        if (custom) {
+            OSSL_PARAM_BLD_push_octet_string(builder, OSSL_MAC_PARAM_CUSTOM,
+                                             custom.bytes, custom.length);
+        }
+        OSSL_PARAM_BLD_push_size_t(builder, OSSL_MAC_PARAM_SIZE, out_size);
+        // Initialize params
+        if (!(params = OSSL_PARAM_BLD_to_param(builder))) {
+            break;
+        }
+        // Initialize MAC CTX
+        if (!EVP_MAC_init(ctx, key.bytes, key.length, params)) {
+            break;
+        }
+        // Update MAC
+        if (!EVP_MAC_update(ctx, data.bytes, data.length)) {
+            break;
+        }
+        // Finalize MAC calculation
+        size_t mac_length;
+        if (!EVP_MAC_final(ctx, result.mutableBytes, &mac_length, result.length)) {
+            break;
+        }
+        if (mac_length != out_size) {
+            break;
+        }
+        success = YES;
+    } while (false);
+    if (params) OSSL_PARAM_free(params);
+    if (builder) OSSL_PARAM_BLD_free(builder);
+    if (ctx) EVP_MAC_CTX_free(ctx);
+    if (mac) EVP_MAC_free(mac);
+    return success ? result : nil;
+}
+
++ (nullable NSData*) hashSha256:(nullable NSData*)data
+{
+    return _CalculateHash(data, EVP_sha256(), 32);
+}
+
++ (nullable NSData*) hmacSha256:(nullable NSData*)data
+                            key:(nonnull NSData*)key
+{
+    return _CalculateMac(data, key, NULL, "HMAC", "SHA-256", 32);
+}
+
++ (nullable NSData*) kmac256:(nullable NSData*)data
+                         key:(nonnull NSData*)key
+                      custom:(nonnull NSData*)custom
+                        size:(NSUInteger)size
+{
+    return _CalculateMac(data, key, custom, "KMAC-256", NULL, size);
 }
 
 + (nullable NSData*) randomBytes:(NSUInteger)count
@@ -45,21 +128,23 @@
     if (count == 0) {
         return nil;
     }
-    NSMutableData * zeros = [NSMutableData dataWithLength:count];
-    NSMutableData * data  = [NSMutableData dataWithLength:count];
-    void * dest_ptr = data.mutableBytes;
-    size_t dest_len = data.length;
-    NSUInteger attempts = 16;
-    while (attempts-- != 0) {
-        if (kCCSuccess != CCRandomGenerateBytes(dest_ptr, dest_len)) {
-            arc4random_buf(dest_ptr, dest_len);
+    NSMutableData * data = [NSMutableData dataWithLength:count];
+    size_t attempts = 16;
+    while (1) {
+        if (1 == RAND_bytes(data.mutableBytes, (int)data.length)) {
+            break;
         }
-        if (![data isEqualToData:zeros]) {
-            return data;
+        if (--attempts == 0) {
+            data = nil;
+            break;
         }
     }
-    PowerAuthLog(@"PA2CoreCryptoUtils: Failed to generat %@ random bytes.", @(count));
-    return nil;
+    return data;
+}
+
++ (nullable NSData*) hashSha3_256:(nullable NSData*)data
+{
+    return _CalculateHash(data, EVP_sha3_256(), 32);
 }
 
 @end

--- a/Sources/PowerAuth2ForWatch/private/PA2CreateTokenTask.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2CreateTokenTask.m
@@ -57,7 +57,8 @@
         if (tokenData && tokenStore) {
             tokenData.activationIdentifier = _activationId;
             tokenData.authenticationFactors = _authentication.signatureFactorMask;
-            token = [[PowerAuthToken alloc] initWithStore:tokenStore data:tokenData];
+            token = [[PowerAuthToken alloc] initWithStore:tokenStore
+                                                     data:tokenData];
         } else {
             token = nil;
             if (!error) {

--- a/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenData.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenData.m
@@ -20,13 +20,11 @@
 #import "PA2PrivateTokenData.h"
 #import "PA2PrivateMacros.h"
 
-#define TOKEN_SECRET_LENGTH     16
-
 @implementation PA2PrivateTokenData
 
 - (BOOL) hasValidData
 {
-    return !(!_name || !_identifier || _secret.length != TOKEN_SECRET_LENGTH);
+    return !(!_name || !_identifier || _secret.length < 16);    // 16 is minimal length for all protocol versions
 }
 
 - (nonnull NSData*)serializedData

--- a/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenInterfaces.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenInterfaces.h
@@ -27,6 +27,17 @@
  */
 @protocol PowerAuthPrivateTokenStore <PowerAuthTokenStore>
 @required
+
+/**
+ Contains current PowerAuth algorithm name.
+ */
+@property (nonatomic, nonnull, readonly, strong) NSString * algorithm;
+
+/**
+ Contains current PowerAuth protocol version (3.3, 4.0, etc.)
+ */
+@property (nonatomic, nonnull, readonly, strong) NSString * protocolVersion;
+
 /**
  Determine whether token can be still used for 
  */

--- a/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenInterfaces.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenInterfaces.h
@@ -31,12 +31,12 @@
 /**
  Contains current PowerAuth algorithm name.
  */
-@property (nonatomic, nonnull, readonly, strong) NSString * algorithm;
+@property (nonatomic, nullable, readonly, strong) NSString * algorithm;
 
 /**
  Contains current PowerAuth protocol version (3.3, 4.0, etc.)
  */
-@property (nonatomic, nonnull, readonly, strong) NSString * protocolVersion;
+@property (nonatomic, nullable, readonly, strong) NSString * protocolVersion;
 
 /**
  Determine whether token can be still used for 

--- a/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.m
@@ -132,6 +132,16 @@
 
 #pragma mark - PowerAuthPrivateTokenStore protocol
 
+- (NSString*) protocolVersion
+{
+    return _statusProvider.powerAuthProtocolVersion;
+}
+
+- (NSString*) algorithm
+{
+    return _statusProvider.powerAuthAlgorithm;
+}
+
 - (BOOL) canGenerateHeaderForToken:(PowerAuthToken *)token
 {
     return [_statusProvider hasValidActivation] && [_statusProvider.activationIdentifier isEqualToString:token.privateTokenData.activationIdentifier];

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket.h
@@ -86,6 +86,12 @@
  */
 @property (nonatomic, assign) BOOL sendLazyResponseIfPossible;
 
+/**
+ Contains `'\0'` by default and if set, then this is a packet response for unsupported
+ protocol version.
+ */
+@property (nonatomic, assign) char customPacketVersion;
+
 // Easy accessors
 
 /**

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_ActivationStatus.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_ActivationStatus.h
@@ -37,5 +37,15 @@
  In this case, presence of activationId determining whether the session is activated or not.
  */
 @property (nonatomic, strong) NSString * activationId;
+/**
+ Optional and has meaning only when activationId is also present. The value contains the current
+ PowerAuth algorithm in the string representation (e.g. `"EC_P384_ML_L3"`).
+ */
+@property (nonatomic, strong) NSString * algorithm;
+/**
+ Optional and has meaning only when activationId is also present. The value contains the current
+ protocol version in string representation (e.g. `"3.3"`, `"4.0"`, etc.)
+ */
+@property (nonatomic, strong) NSString * protocolVersion;
 
 @end

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_ActivationStatus.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_ActivationStatus.m
@@ -29,6 +29,12 @@
     if (_activationId) {
         dictionary[PA2WCSessionPacket_KEY_ACTIVATION_ID] = _activationId;
     }
+    if (_algorithm) {
+        dictionary[PA2WCSessionPacket_KEY_ALGORITHM_ID] = _algorithm;
+    }
+    if (_protocolVersion) {
+        dictionary[PA2WCSessionPacket_KEY_PROTO_VERSION] = _protocolVersion;
+    }
 }
 
 - (id) initWithDictionary:(NSDictionary *)dictionary
@@ -37,6 +43,8 @@
     if (self) {
         _command = PA2ObjectAs(dictionary[PA2WCSessionPacket_KEY_ACTIVATION_CMD], NSString);
         _activationId = PA2ObjectAs(dictionary[PA2WCSessionPacket_KEY_ACTIVATION_ID], NSString);
+        _algorithm = PA2ObjectAs(dictionary[PA2WCSessionPacket_KEY_ALGORITHM_ID], NSString);
+        _protocolVersion = PA2ObjectAs(dictionary[PA2WCSessionPacket_KEY_PROTO_VERSION], NSString);
     }
     return self;
 }

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_Constants.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_Constants.h
@@ -18,7 +18,7 @@
 
 #import <PowerAuth2ForWatch/PowerAuthMacros.h>
 
-// Key used in userInfo, transmitted over the
+// Key used in userInfo
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_USER_INFO_KEY;
 
 // value for "target" property, when response is transmitted.
@@ -38,6 +38,8 @@ PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_ERROR_MSG;
 // Constants for serializing activation status
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_ACTIVATION_CMD;
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_ACTIVATION_ID;
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_ALGORITHM_ID;
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_PROTO_VERSION;
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_CMD_SESSION_GET;
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_CMD_SESSION_PUT;
 

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_Constants.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_Constants.m
@@ -18,29 +18,30 @@
 
 #import "PA2WCSessionPacket_Constants.h"
 
-NSString * const PA2WCSessionPacket_USER_INFO_KEY       = @"io.getlime.PowerAuth.PA2WCSessionPacket";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_USER_INFO_KEY       = @"com.wultra.PowerAuth.PA2WCSessionPacket";
 
-NSString * const PA2WCSessionPacket_RESPONSE_TARGET     = @"*";
-NSString * const PA2WCSessionPacket_SESSION_TARGET      = @"session:";
-NSString * const PA2WCSessionPacket_TOKEN_TARGET        = @"token:";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_RESPONSE_TARGET     = @"*";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_SESSION_TARGET      = @"session:";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_TOKEN_TARGET        = @"token:";
 
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_TARGET          = @"target";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ERROR_CODE      = @"errorCode";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ERROR_DOM       = @"errorDomain";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ERROR_MSG       = @"errorMsg";
 
-NSString * const PA2WCSessionPacket_KEY_TARGET          = @"target";
-NSString * const PA2WCSessionPacket_KEY_ERROR_CODE      = @"errorCode";
-NSString * const PA2WCSessionPacket_KEY_ERROR_DOM       = @"errorDomain";
-NSString * const PA2WCSessionPacket_KEY_ERROR_MSG       = @"errorMsg";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ACTIVATION_CMD  = @"activationCmd";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ACTIVATION_ID   = @"activationId";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ALGORITHM_ID    = @"activationAlg";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_PROTO_VERSION   = @"activationProto";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_SESSION_GET     = @"get_session";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_SESSION_PUT     = @"put_session";
 
-NSString * const PA2WCSessionPacket_KEY_ACTIVATION_CMD  = @"activationCmd";
-NSString * const PA2WCSessionPacket_KEY_ACTIVATION_ID   = @"activationId";
-NSString * const PA2WCSessionPacket_CMD_SESSION_GET     = @"get_session";
-NSString * const PA2WCSessionPacket_CMD_SESSION_PUT     = @"put_session";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_TOKEN_CMD       = @"tokenCmd";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_TOKEN_NAME      = @"tokenName";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_TOKEN_DATA      = @"tokenData";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_TOKEN_NA        = @"tokenNotFound";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_TOKEN_GET       = @"get_token";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_TOKEN_PUT       = @"put_token";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_TOKEN_REMOVE    = @"remove_token";
 
-NSString * const PA2WCSessionPacket_KEY_TOKEN_CMD       = @"tokenCmd";
-NSString * const PA2WCSessionPacket_KEY_TOKEN_NAME      = @"tokenName";
-NSString * const PA2WCSessionPacket_KEY_TOKEN_DATA      = @"tokenData";
-NSString * const PA2WCSessionPacket_KEY_TOKEN_NA        = @"tokenNotFound";
-NSString * const PA2WCSessionPacket_CMD_TOKEN_GET       = @"get_token";
-NSString * const PA2WCSessionPacket_CMD_TOKEN_PUT       = @"put_token";
-NSString * const PA2WCSessionPacket_CMD_TOKEN_REMOVE    = @"remove_token";
-
-NSString * const PA2WCSessionPacket_KEY_SUCCESS         = @"successCode";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_SUCCESS         = @"successCode";

--- a/Sources/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.h
@@ -41,7 +41,7 @@
 - (nullable NSString*) activationIdForSessionInstanceId:(nonnull NSString*)sessionInstanceId;
 
 /**
- Returns activation status objdct for given session instance identifier. In fact, if the non-nil value is
+ Returns activation status object for given session instance identifier. In fact, if the non-nil value is
  returned, then the requested session is still valid.
  */
 - (nullable PA2ActivationStatus*) activationStatusForSessionInstanceId:(nonnull NSString*)sessionInstanceId;

--- a/Sources/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.h
@@ -15,6 +15,9 @@
  */
 
 #import "PA2WCSessionDataHandler.h"
+#import "PA2ActivationStatus.h"
+
+@class PA2WCSessionPacket_ActivationStatus;
 
 /**
  On watchOS, the PA2WatchSynchronizationService class is responsible for processing
@@ -38,8 +41,14 @@
 - (nullable NSString*) activationIdForSessionInstanceId:(nonnull NSString*)sessionInstanceId;
 
 /**
+ Returns activation status objdct for given session instance identifier. In fact, if the non-nil value is
+ returned, then the requested session is still valid.
+ */
+- (nullable PA2ActivationStatus*) activationStatusForSessionInstanceId:(nonnull NSString*)sessionInstanceId;
+
+/**
  Removes or adds activation for given session instance identifier, depending on nullability of activationId.
  */
-- (void) updateActivationId:(nullable NSString*)activationId forSessionInstanceId:(nonnull NSString*)sessionInstanceId;
+- (void) updateActivationStatus:(nullable PA2WCSessionPacket_ActivationStatus*)activationStatus forSessionInstanceId:(nonnull NSString*)sessionInstanceId;
 
 @end

--- a/Sources/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.m
@@ -19,6 +19,7 @@
 #import "PA2WCSessionPacket_ActivationStatus.h"
 #import "PA2WCSessionPacket_TokenData.h"
 #import "PA2WCSessionPacket_Success.h"
+#import "PA2ActivationStatus.h"
 
 #import "PA2PrivateMacros.h"
 #import "PA2PrivateTokenData.h"
@@ -60,37 +61,43 @@
 
 #pragma mark - Public methods
 
-- (NSString*) activationIdForSessionInstanceId:(nonnull NSString*)sessionInstanceId
+- (NSString*) activationIdForSessionInstanceId:(NSString*)sessionInstanceId
+{
+    return [self activationStatusForSessionInstanceId:sessionInstanceId].activationId;
+}
+
+- (PA2ActivationStatus*) activationStatusForSessionInstanceId:(NSString*)sessionInstanceId
 {
     if (sessionInstanceId.length > 0) {
         NSData * statusData = [_statusKeychain dataForKey:sessionInstanceId status:NULL];
-        if (statusData.length > 0) {
-            return [[NSString alloc] initWithData:statusData encoding:NSUTF8StringEncoding];
+        if (statusData) {
+            return [PA2ActivationStatus fromData:statusData];
         }
     }
     return nil;
 }
 
-- (void) updateActivationId:(nullable NSString*)activationId forSessionInstanceId:(nonnull NSString*)sessionInstanceId
+- (void) updateActivationStatus:(nullable PA2WCSessionPacket_ActivationStatus*)activationStatus forSessionInstanceId:(nonnull NSString*)sessionInstanceId
 {
     if (sessionInstanceId.length > 0) {
         BOOL removeAssociatedTokens = NO;
-        NSData * currentData = [_statusKeychain dataForKey:sessionInstanceId status:NULL];
-        if (activationId) {
-            NSData * activationIdData = [activationId dataUsingEncoding:NSUTF8StringEncoding];
-            if (currentData) {
-                if (![currentData isEqualToData:activationIdData]) {
-                    [_statusKeychain updateValue:activationIdData forKey:sessionInstanceId];
+        NSData * currentStatusData = [_statusKeychain dataForKey:sessionInstanceId status:NULL];
+        PA2ActivationStatus * currentStatus = currentStatusData ? [PA2ActivationStatus fromData:currentStatusData] : nil;
+        if (activationStatus) {
+            PA2ActivationStatus * newStatus = [PA2ActivationStatus fromPacket:activationStatus];
+            if (currentStatus) {
+                if (![currentStatus.activationId isEqualToString:newStatus.activationId]) {
+                    [_statusKeychain updateValue:[newStatus toData] forKey:sessionInstanceId];
                     PowerAuthLog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is now activated (with different activation ID).", sessionInstanceId);
                     removeAssociatedTokens = YES;
                 }
             } else {
-                [_statusKeychain addValue:activationIdData forKey:sessionInstanceId];
+                [_statusKeychain addValue:[newStatus toData] forKey:sessionInstanceId];
                 PowerAuthLog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is now activated.", sessionInstanceId);
             }
         } else {
             // Removing activation status
-            if (currentData) {
+            if (currentStatus) {
                 [_statusKeychain deleteDataForKey:sessionInstanceId];
                 PowerAuthLog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is no longer activated.", sessionInstanceId);
             }
@@ -162,7 +169,7 @@
         NSString * command = status.command;
         if ([command isEqualToString:PA2WCSessionPacket_CMD_SESSION_PUT]) {
             // Update session status
-            [self updateActivationId:status.activationId forSessionInstanceId:instanceId];
+            [self updateActivationStatus:status forSessionInstanceId:instanceId];
             //
         } else {
             //

--- a/Sources/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.m
@@ -82,14 +82,19 @@
     if (sessionInstanceId.length > 0) {
         BOOL removeAssociatedTokens = NO;
         NSData * currentStatusData = [_statusKeychain dataForKey:sessionInstanceId status:NULL];
-        PA2ActivationStatus * currentStatus = currentStatusData ? [PA2ActivationStatus fromData:currentStatusData] : nil;
-        if (activationStatus) {
+        PA2ActivationStatus * currentStatus = [PA2ActivationStatus fromData:currentStatusData];
+        if (activationStatus.activationId.length > 0) {
             PA2ActivationStatus * newStatus = [PA2ActivationStatus fromPacket:activationStatus];
             if (currentStatus) {
-                if (![currentStatus.activationId isEqualToString:newStatus.activationId]) {
+                if (![currentStatus isEqual:newStatus]) {
+                    // Status object changed. We have to store the new status and take a special care if activation ID has been changed.
                     [_statusKeychain updateValue:[newStatus toData] forKey:sessionInstanceId];
-                    PowerAuthLog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is now activated (with different activation ID).", sessionInstanceId);
-                    removeAssociatedTokens = YES;
+                    removeAssociatedTokens = ![currentStatus.activationId isEqualToString:newStatus.activationId];
+                    if (removeAssociatedTokens) {
+                        PowerAuthLog(@"PA2WatchSynchronizationService: Session with instanceId '%@' is now activated (with different activation ID).", sessionInstanceId);
+                    } else {
+                        PowerAuthLog(@"PA2WatchSynchronizationService: Session with instanceId '%@' updated.", sessionInstanceId);
+                    }
                 }
             } else {
                 [_statusKeychain addValue:[newStatus toData] forKey:sessionInstanceId];

--- a/scripts/templates/PowerAuth2ForWatch.podspec
+++ b/scripts/templates/PowerAuth2ForWatch.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
     s.summary           = 'PowerAuth Mobile SDK for watchOS'
     s.homepage          = 'https://github.com/wultra/powerauth-mobile-sdk'
     s.social_media_url  = 'https://twitter.com/wultra'
-    s.documentation_url = 'https://developers.wultra.com/products/mobile-security-suite/develop/powerauth-mobile-sdk/PowerAuth-SDK-for-watchOS'
+    s.documentation_url = 'https://github.com/wultra/powerauth-mobile-sdk/blob/develop/docs/PowerAuth-SDK-for-watchOS.md'
     s.author            = { 
       'Wultra s.r.o.' => 'support@wultra.com'
     }
@@ -18,7 +18,8 @@ Pod::Spec.new do |s|
     # Source files
     s.source = { 
         :git => 'https://github.com/wultra/powerauth-mobile-watch-sdk.git',
-        :tag => "#{s.version}"
+        :tag => "#{s.version}",
+        :submodules => true
     }
     
     # Library build


### PR DESCRIPTION
This PR adds ability to calculate a V4 token headers to the watchOS SDK. The change also contains a communication protocol change that allows to handle the current and the future protocol version updates. 

Library now depends on OpenSSL, integrated via `cc7` submodule (our platform for custom OpenSSL build)