### PR TITLE
Fix #7: Synchronize time with iOS

### DIFF
--- a/PowerAuth2ForWatch.xcodeproj/project.pbxproj
+++ b/PowerAuth2ForWatch.xcodeproj/project.pbxproj
@@ -76,6 +76,14 @@
 		BFE88CC62F741C570072B083 /* PowerAuthHttpHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE88CC42F741C570072B083 /* PowerAuthHttpHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFE88CC72F741C570072B083 /* PowerAuthHttpHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = BFE88CC52F741C570072B083 /* PowerAuthHttpHeader.m */; };
 		BFE88CC92F741D710072B083 /* PowerAuthHttpHeader+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE88CC82F741D710072B083 /* PowerAuthHttpHeader+Private.h */; };
+		BFE88CDB2F7BE8D50072B083 /* PA2WCSessionDataHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = BFE88CDA2F7BE8D50072B083 /* PA2WCSessionDataHandler.m */; };
+		BFE88CDE2F7BE8ED0072B083 /* PA2WCSessionPacket_TimeSync.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE88CDC2F7BE8ED0072B083 /* PA2WCSessionPacket_TimeSync.h */; };
+		BFE88CDF2F7BE8ED0072B083 /* PA2WCSessionPacket_TimeSync.m in Sources */ = {isa = PBXBuildFile; fileRef = BFE88CDD2F7BE8ED0072B083 /* PA2WCSessionPacket_TimeSync.m */; };
+		BFE88CE12F7BEA210072B083 /* PowerAuthTimeSynchronizationService.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE88CE02F7BEA210072B083 /* PowerAuthTimeSynchronizationService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFE88CE42F7BEAFF0072B083 /* PA2WatchTimeSynchronizationService.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE88CE22F7BEAFF0072B083 /* PA2WatchTimeSynchronizationService.h */; };
+		BFE88CE52F7BEAFF0072B083 /* PA2WatchTimeSynchronizationService.m in Sources */ = {isa = PBXBuildFile; fileRef = BFE88CE32F7BEAFF0072B083 /* PA2WatchTimeSynchronizationService.m */; };
+		BFE88CE82F7BFA2D0072B083 /* PA2CompositeTask.h in Headers */ = {isa = PBXBuildFile; fileRef = BFE88CE62F7BFA2D0072B083 /* PA2CompositeTask.h */; };
+		BFE88CE92F7BFA2D0072B083 /* PA2CompositeTask.m in Sources */ = {isa = PBXBuildFile; fileRef = BFE88CE72F7BFA2D0072B083 /* PA2CompositeTask.m */; };
 		BFFC5E162F7160FF00A1411B /* PA2ActivationStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = BFFC5E152F7160FF00A1411B /* PA2ActivationStatus.m */; };
 		BFFC5E172F7160FF00A1411B /* PA2ActivationStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = BFFC5E142F7160FF00A1411B /* PA2ActivationStatus.h */; };
 /* End PBXBuildFile section */
@@ -163,6 +171,14 @@
 		BFE88CC42F741C570072B083 /* PowerAuthHttpHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthHttpHeader.h; sourceTree = "<group>"; };
 		BFE88CC52F741C570072B083 /* PowerAuthHttpHeader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuthHttpHeader.m; sourceTree = "<group>"; };
 		BFE88CC82F741D710072B083 /* PowerAuthHttpHeader+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PowerAuthHttpHeader+Private.h"; sourceTree = "<group>"; };
+		BFE88CDA2F7BE8D50072B083 /* PA2WCSessionDataHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2WCSessionDataHandler.m; sourceTree = "<group>"; };
+		BFE88CDC2F7BE8ED0072B083 /* PA2WCSessionPacket_TimeSync.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2WCSessionPacket_TimeSync.h; sourceTree = "<group>"; };
+		BFE88CDD2F7BE8ED0072B083 /* PA2WCSessionPacket_TimeSync.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2WCSessionPacket_TimeSync.m; sourceTree = "<group>"; };
+		BFE88CE02F7BEA210072B083 /* PowerAuthTimeSynchronizationService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthTimeSynchronizationService.h; sourceTree = "<group>"; };
+		BFE88CE22F7BEAFF0072B083 /* PA2WatchTimeSynchronizationService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2WatchTimeSynchronizationService.h; sourceTree = "<group>"; };
+		BFE88CE32F7BEAFF0072B083 /* PA2WatchTimeSynchronizationService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2WatchTimeSynchronizationService.m; sourceTree = "<group>"; };
+		BFE88CE62F7BFA2D0072B083 /* PA2CompositeTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2CompositeTask.h; sourceTree = "<group>"; };
+		BFE88CE72F7BFA2D0072B083 /* PA2CompositeTask.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2CompositeTask.m; sourceTree = "<group>"; };
 		BFFC5E062F6D6B5E00A1411B /* openssl.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = openssl.xcodeproj; path = "cc7/proj-xcode/openssl.xcodeproj"; sourceTree = "<group>"; };
 		BFFC5E142F7160FF00A1411B /* PA2ActivationStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PA2ActivationStatus.h; sourceTree = "<group>"; };
 		BFFC5E152F7160FF00A1411B /* PA2ActivationStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PA2ActivationStatus.m; sourceTree = "<group>"; };
@@ -184,6 +200,8 @@
 			children = (
 				BF4B3588285209CA009A03EF /* PowerAuthAuthentication+Private.h */,
 				BFE88CC82F741D710072B083 /* PowerAuthHttpHeader+Private.h */,
+				BFE88CE22F7BEAFF0072B083 /* PA2WatchTimeSynchronizationService.h */,
+				BFE88CE32F7BEAFF0072B083 /* PA2WatchTimeSynchronizationService.m */,
 			);
 			name = sdk;
 			sourceTree = "<group>";
@@ -236,6 +254,7 @@
 				BF1ED0AA2844C2E400D6B380 /* PowerAuthOperationTask.h */,
 				BF86E82B263C1EBD004C8AE5 /* PowerAuthSystem.h */,
 				BF86E81F263C1EBD004C8AE5 /* PowerAuthSystem.m */,
+				BFE88CE02F7BEA210072B083 /* PowerAuthTimeSynchronizationService.h */,
 				BF86E828263C1EBD004C8AE5 /* PowerAuthWCSessionManager.h */,
 				BF86E851263C1EBE004C8AE5 /* PowerAuthWCSessionManager.m */,
 				BF86E8B6263C2512004C8AE5 /* PowerAuthDeprecated.h */,
@@ -268,6 +287,8 @@
 				BF86E8BF263C2706004C8AE5 /* PA2PrivateConstants.h */,
 				BF86E8D4263C2BBF004C8AE5 /* PA2CoreCryptoUtils.h */,
 				BF86E8D5263C2BBF004C8AE5 /* PA2CoreCryptoUtils.m */,
+				BFE88CE62F7BFA2D0072B083 /* PA2CompositeTask.h */,
+				BFE88CE72F7BFA2D0072B083 /* PA2CompositeTask.m */,
 				BF1ED0AC2844C3FD00D6B380 /* PA2SimpleCancelable.h */,
 				BF1ED0AD2844C3FD00D6B380 /* PA2SimpleCancelable.m */,
 			);
@@ -297,6 +318,7 @@
 			children = (
 				BF86E89D263C2086004C8AE5 /* model */,
 				BF86E831263C1EBD004C8AE5 /* PA2WCSessionDataHandler.h */,
+				BFE88CDA2F7BE8D50072B083 /* PA2WCSessionDataHandler.m */,
 				BF86E830263C1EBD004C8AE5 /* PA2WatchSynchronizationService.h */,
 				BF86E83D263C1EBD004C8AE5 /* PA2WatchSynchronizationService.m */,
 				BF86E847263C1EBD004C8AE5 /* PowerAuthWCSessionManager+Private.h */,
@@ -318,6 +340,8 @@
 				BF86E83B263C1EBD004C8AE5 /* PA2WCSessionPacket_Success.m */,
 				BF86E844263C1EBD004C8AE5 /* PA2WCSessionPacket_TokenData.h */,
 				BF86E837263C1EBD004C8AE5 /* PA2WCSessionPacket_TokenData.m */,
+				BFE88CDC2F7BE8ED0072B083 /* PA2WCSessionPacket_TimeSync.h */,
+				BFE88CDD2F7BE8ED0072B083 /* PA2WCSessionPacket_TimeSync.m */,
 				BFFC5E142F7160FF00A1411B /* PA2ActivationStatus.h */,
 				BFFC5E152F7160FF00A1411B /* PA2ActivationStatus.m */,
 			);
@@ -361,16 +385,20 @@
 				BF86E85C263C1EBE004C8AE5 /* PowerAuth2ForWatch.h in Headers */,
 				BF86E858263C1EBE004C8AE5 /* PowerAuthSessionStatusProvider.h in Headers */,
 				BF86E885263C1EBE004C8AE5 /* PowerAuthMacros.h in Headers */,
+				BFE88CE42F7BEAFF0072B083 /* PA2WatchTimeSynchronizationService.h in Headers */,
 				BFE88CC92F741D710072B083 /* PowerAuthHttpHeader+Private.h in Headers */,
 				BF1ED0AB2844C2E400D6B380 /* PowerAuthOperationTask.h in Headers */,
 				BF86E86F263C1EBE004C8AE5 /* PA2PrivateTokenData.h in Headers */,
 				BF86E87B263C1EBE004C8AE5 /* PA2WeakArray.h in Headers */,
 				BF86E86E263C1EBE004C8AE5 /* PA2PrivateMacros.h in Headers */,
+				BFE88CE82F7BFA2D0072B083 /* PA2CompositeTask.h in Headers */,
 				BF86E867263C1EBE004C8AE5 /* PA2WCSessionDataHandler.h in Headers */,
 				BF86E862263C1EBE004C8AE5 /* PowerAuthSystem.h in Headers */,
+				BFE88CDE2F7BE8ED0072B083 /* PA2WCSessionPacket_TimeSync.h in Headers */,
 				BF86E883263C1EBE004C8AE5 /* PowerAuthErrorConstants.h in Headers */,
 				BF86E866263C1EBE004C8AE5 /* PA2WatchSynchronizationService.h in Headers */,
 				BF86E87F263C1EBE004C8AE5 /* PA2WCSessionPacket_Success.h in Headers */,
+				BFE88CE12F7BEA210072B083 /* PowerAuthTimeSynchronizationService.h in Headers */,
 				BF1ED07A283D01CC00D6B380 /* PowerAuthKeychainAuthentication.h in Headers */,
 				BF86E86C263C1EBE004C8AE5 /* PA2WatchRemoteTokenProvider.h in Headers */,
 				BF86E8C0263C2707004C8AE5 /* PA2PrivateConstants.h in Headers */,
@@ -501,22 +529,26 @@
 				BF86E86D263C1EBE004C8AE5 /* PA2WCSessionPacket_TokenData.m in Sources */,
 				BF86E873263C1EBE004C8AE5 /* PA2WatchSynchronizationService.m in Sources */,
 				BF1ED0CA284775E200D6B380 /* PA2GroupedTask.m in Sources */,
+				BFE88CE52F7BEAFF0072B083 /* PA2WatchTimeSynchronizationService.m in Sources */,
 				BF86E8B9263C2512004C8AE5 /* PowerAuthDeprecated.m in Sources */,
 				BF1ED0AF2844C3FD00D6B380 /* PA2SimpleCancelable.m in Sources */,
 				BF86E889263C1EBE004C8AE5 /* PowerAuthKeychain.m in Sources */,
 				BF86E857263C1EBE004C8AE5 /* PowerAuthLog.m in Sources */,
 				BF86E881263C1EBE004C8AE5 /* PowerAuthAuthentication.m in Sources */,
 				BF86E856263C1EBE004C8AE5 /* PowerAuthSystem.m in Sources */,
+				BFE88CE92F7BFA2D0072B083 /* PA2CompositeTask.m in Sources */,
 				BF86E888263C1EBE004C8AE5 /* PowerAuthConfiguration.m in Sources */,
 				BF1ED0CE284775FA00D6B380 /* PA2CreateTokenTask.m in Sources */,
 				BF86E86B263C1EBE004C8AE5 /* PA2WeakArray.m in Sources */,
 				BF86E865263C1EBE004C8AE5 /* PowerAuthWCSessionManager_WatchServices.m in Sources */,
 				BF86E871263C1EBE004C8AE5 /* PA2WCSessionPacket_Success.m in Sources */,
+				BFE88CDB2F7BE8D50072B083 /* PA2WCSessionDataHandler.m in Sources */,
 				BFFC5E162F7160FF00A1411B /* PA2ActivationStatus.m in Sources */,
 				BFE88CC72F741C570072B083 /* PowerAuthHttpHeader.m in Sources */,
 				BF86E85B263C1EBE004C8AE5 /* PowerAuthErrorConstants.m in Sources */,
 				BF86E886263C1EBE004C8AE5 /* PowerAuthWCSessionManager.m in Sources */,
 				BF86E8B0263C231B004C8AE5 /* PowerAuthToken.m in Sources */,
+				BFE88CDF2F7BE8ED0072B083 /* PA2WCSessionPacket_TimeSync.m in Sources */,
 				BF86E868263C1EBE004C8AE5 /* PA2WCSessionPacket_Constants.m in Sources */,
 				BF86E878263C1EBE004C8AE5 /* PA2PrivateTokenData.m in Sources */,
 				BF86E877263C1EBE004C8AE5 /* PA2WCSessionPacket.m in Sources */,

--- a/Sources/PowerAuth2ForWatch/PowerAuth2ForWatch.h
+++ b/Sources/PowerAuth2ForWatch/PowerAuth2ForWatch.h
@@ -35,4 +35,5 @@ FOUNDATION_EXPORT const unsigned char PowerAuth2ForWatchVersionString[];
 #import <PowerAuth2ForWatch/PowerAuthLog.h>
 #import <PowerAuth2ForWatch/PowerAuthSystem.h>
 #import <PowerAuth2ForWatch/PowerAuthWCSessionManager.h>
+#import <PowerAuth2ForWatch/PowerAuthTimeSynchronizationService.h>
 #import <PowerAuth2ForWatch/PowerAuthDeprecated.h>

--- a/Sources/PowerAuth2ForWatch/PowerAuthTimeSynchronizationService.h
+++ b/Sources/PowerAuth2ForWatch/PowerAuthTimeSynchronizationService.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <PowerAuth2ForWatch/PowerAuthOperationTask.h>
+
+/// The `PowerAuthTimeSynchronizationService` protocol defines interface that allows you to synchronize the
+/// local device time with the PowerAuth Server and then get the synchronized time.
+@protocol PowerAuthTimeSynchronizationService <NSObject>
+@required
+
+/// Contains information whether the service has its time synchronized with the server.
+@property (nonatomic, readonly) BOOL isTimeSynchronized;
+
+/// Contains calculated local time difference against the server. The value of the property
+/// is informational and is provided only for the testing or the debugging purposes.
+@property (nonatomic, readonly) NSTimeInterval localTimeAdjustment;
+
+/// Contains value representing a maximum absolute deviation of synchronized time against the actual time on the server.
+/// Depending on this value you can determine whether this deviation is within your expected margins. If the current
+/// synchronized time is out of your expectations, then try to synchronize the time again.
+@property (nonatomic, readonly) NSTimeInterval localTimeAdjustmentPrecision;
+
+/// Return the current local time synchronized with the server. The returned value is in the seconds since the
+/// reference date 1.1.1970 (e.g. unix timestamp.) If the local time is not synchronized, then returns
+/// the current local time (e.g. `Date().timeIntervalSince1970`.) You can test `isTimeSynchronized` property if
+/// this is not sufficient for your purposes.
+- (NSTimeInterval) currentTime;
+
+/// Synchronize the local with the time on the server.
+/// - Parameter callback: Callback called once the synchronization task is complete. If the error parameter is `nil` then everything's OK.
+/// - Parameter callbackQueue: Queue for completion callback execution. If nil, then the main dispatch queue is used.
+/// - Returns: Task associated with the running HTTP request or nil in case that PowerAuthSDK instance is no longer valid.
+- (nullable id<PowerAuthOperationTask>) synchronizeTimeWithCallback:(void (^_Nonnull)(NSError * _Nullable error))callback
+                                                      callbackQueue:(dispatch_queue_t _Nullable)callbackQueue;
+
+/// Reset the time synchronization. The time must be synchronized again after this call.
+- (void) resetTimeSynchronization;
+
+@end

--- a/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.h
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.h
@@ -53,7 +53,7 @@
  then you have to always provide the reply handler to this method.
  */
 - (BOOL) processReceivedMessageData:(nonnull NSData *)data
-                       replyHandler:(void (^ _Nullable)(NSData * _Nonnull reply))replyHandler;
+                       replyHandler:(void (^_Nullable)(NSData * _Nonnull reply))replyHandler;
 
 /**
  Processes a received user info and returns YES if information has been consumed (e.g. PowerAuth

--- a/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Wultra s.r.o.
+ * Copyright 2026 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,10 +211,9 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 #pragma mark - Message processing
 
 - (BOOL) processReceivedMessageData:(nonnull NSData *)data
-                       replyHandler:(void (^ _Nullable)(NSData * _Nonnull reply))replyHandler
+                       replyHandler:(void (^_Nullable)(NSData * _Nonnull reply))replyHandler
 {
-    PA2WCSessionPacket * response = nil;
-    NSString * errorMessage = nil;
+    PA2WCSessionDataHandlerResponse * response = nil;
     do {
         BOOL failure;
         PA2WCSessionPacket * packet = _DeserializePacket(data, Nil, &failure);
@@ -224,49 +223,54 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
         }
         if (failure) {
             // Incoming packet processing raised an error. This is already the response.
-            response = packet;
-            errorMessage = response.error.localizedDescription;
+            response = [PA2WCSessionDataHandlerResponse responseWithPacket:packet];
             break;
         }
         //
         NSString * target = packet.target;
         if ([target isEqualToString:PA2WCSessionPacket_RESPONSE_TARGET]) {
-            errorMessage = @"PA2WCSessionManager: Requests with response target are not allowed.";
+            response = [PA2WCSessionDataHandlerResponse responseWithErrorMessage:@"PA2WCSessionManager: Requests with response target are not allowed."];
             break;
         }
         // Look for handler
         id<PA2WCSessionDataHandler> handler = [self handlerForPacket:packet];
         if (!handler) {
-            errorMessage = [NSString stringWithFormat:@"PA2WCSessionManager: Unable to handle request for target '%@'.", target];
+            response = [PA2WCSessionDataHandlerResponse responseWithErrorMessage:
+                            [NSString stringWithFormat:@"PA2WCSessionManager: Unable to handle request for target '%@'.", target]];
             break;
         }
         // ...and finally get the response
         packet.requestWithoutReplyHandler = replyHandler == nil;
         response = [handler sessionManager:self responseForPacket:packet];
+        if (!response) {
+            response = [PA2WCSessionDataHandlerResponse responseWithErrorMessage:
+                            [NSString stringWithFormat:@"PA2WCSessionManager: Failed to create response for target '%@'.", target]];
+        }
         
     } while (false);
     
-    // Send back response, if replyHandler is valid
-    if (replyHandler != nil) {
-        if (!response) {
-            if (!errorMessage) {
-                errorMessage = @"PA2WCSessionManager: Cannot create response packet.";
-            }
-            PowerAuthLog(@"%@", errorMessage);
-            NSError * error = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, errorMessage);
-            response = [PA2WCSessionPacket packetWithError:error];
-        }
-        replyHandler(_SerializePacket(response));
+    // Send response back, if packet is already present
+    PA2WCSessionPacket * responsePacket = response.responsePacket;
+    if (!responsePacket) {
+        // Delayed completion
+        [response setCompletionCallback:^(PA2WCSessionPacket *responsePacket) {
+            [self sendResponsePacket:responsePacket replyHandler:replyHandler];
+        }];
     } else {
-        if (errorMessage) {
-            PowerAuthLog(@"%@", errorMessage);
-        } else if (response.sendLazyResponseIfPossible) {
-            [self sendPacket:response];
-        }
+        [self sendResponsePacket:responsePacket replyHandler:replyHandler];
     }
     return YES;
 }
 
+- (void) sendResponsePacket:(nonnull PA2WCSessionPacket *)responsePacket
+               replyHandler:(void (^_Nullable)(NSData * _Nonnull reply))replyHandler
+{
+    if (replyHandler) {
+        replyHandler(_SerializePacket(responsePacket));
+    } else {
+        [self sendPacket:responsePacket];
+    }
+}
 
 - (BOOL) processReceivedUserInfo:(NSDictionary<NSString *,id> *)userInfo
 {

--- a/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWCSessionManager.m
@@ -267,8 +267,10 @@ static NSData * _SerializePacket(PA2WCSessionPacket * packet)
 {
     if (replyHandler) {
         replyHandler(_SerializePacket(responsePacket));
-    } else {
+    } else if (responsePacket.sendLazyResponseIfPossible) {
         [self sendPacket:responsePacket];
+    } else {
+        PowerAuthLog(@"PowerAuthWCSessionManager: Dropping response for fire-and-forget request because no reply handler is available.");
     }
 }
 

--- a/Sources/PowerAuth2ForWatch/PowerAuthWatchSDK.h
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWatchSDK.h
@@ -38,12 +38,13 @@
 @property (nonatomic, strong, nonnull, readonly) PowerAuthConfiguration * configuration;
 
 /**
- Object providing functions to synchronize time with the server. The time is automatically synchronized with the server.
+ Object providing functions to synchronize time with the server.
  */
 @property (nonatomic, strong, nonnull, readonly) id<PowerAuthTimeSynchronizationService> timeSynchronizationService;
 
 /**
  A designated initializer.
+ @param configuration Configuration object.
  */
 - (nullable instancetype) initWithConfiguration:(nonnull PowerAuthConfiguration*)configuration
                                           error:(NSError*_Nullable*_Nullable)error;

--- a/Sources/PowerAuth2ForWatch/PowerAuthWatchSDK.h
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWatchSDK.h
@@ -18,6 +18,7 @@
 #import <PowerAuth2ForWatch/PowerAuthToken.h>
 #import <PowerAuth2ForWatch/PowerAuthSessionStatusProvider.h>
 #import <PowerAuth2ForWatch/PowerAuthKeychainConfiguration.h>
+#import <PowerAuth2ForWatch/PowerAuthTimeSynchronizationService.h>
 #import <PowerAuth2ForWatch/PowerAuthHttpHeader.h>
 
 @interface PowerAuthWatchSDK : NSObject<PowerAuthSessionStatusProvider>
@@ -37,9 +38,15 @@
 @property (nonatomic, strong, nonnull, readonly) PowerAuthConfiguration * configuration;
 
 /**
+ Object providing functions to synchronize time with the server. The time is automatically synchronized with the server.
+ */
+@property (nonatomic, strong, nonnull, readonly) id<PowerAuthTimeSynchronizationService> timeSynchronizationService;
+
+/**
  A designated initializer.
  */
-- (nullable instancetype) initWithConfiguration:(nonnull PowerAuthConfiguration*)configuration;
+- (nullable instancetype) initWithConfiguration:(nonnull PowerAuthConfiguration*)configuration
+                                          error:(NSError*_Nullable*_Nullable)error;
 
 @end
 

--- a/Sources/PowerAuth2ForWatch/PowerAuthWatchSDK.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWatchSDK.m
@@ -49,7 +49,7 @@
 {
     self = [super init];
     if (self) {
-        if (![_configuration validateConfiguration]) {
+        if (![configuration validateConfiguration]) {
             PA2SetError(error, PowerAuthErrorCode_WrongParameter, @"Invalid configuration provided");
             return nil;
         }

--- a/Sources/PowerAuth2ForWatch/PowerAuthWatchSDK.m
+++ b/Sources/PowerAuth2ForWatch/PowerAuthWatchSDK.m
@@ -16,12 +16,15 @@
 
 #import <PowerAuth2ForWatch/PowerAuthWatchSDK.h>
 #import <PowerAuth2ForWatch/PowerAuthKeychain.h>
+#import <PowerAuth2ForWatch/PowerAuthWCSessionManager.h>
 #import <PowerAuth2ForWatch/PowerAuthLog.h>
 
 #import "PA2WatchSynchronizationService.h"
 #import "PA2WatchRemoteTokenProvider.h"
 #import "PA2PrivateTokenKeychainStore.h"
+#import "PA2WatchTimeSynchronizationService.h"
 #import "PA2PrivateMacros.h"
+#import "PA2CompositeTask.h"
 
 #import "PA2WCSessionPacket_ActivationStatus.h"
 #import "PowerAuthWCSessionManager+Private.h"
@@ -42,22 +45,35 @@
 #pragma mark - Init
 
 - (id) initWithConfiguration:(PowerAuthConfiguration *)configuration
+                       error:(NSError**)error
 {
     self = [super init];
     if (self) {
+        if (![_configuration validateConfiguration]) {
+            PA2SetError(error, PowerAuthErrorCode_WrongParameter, @"Invalid configuration provided");
+            return nil;
+        }
         _configuration = [configuration copy];
         _lock = [[NSRecursiveLock alloc] init];
         
+        // Prepare time synchronization service
+        PA2WatchTimeSynchronizationService * timeService = [[PA2WatchTimeSynchronizationService alloc] initWithInstanceId:_configuration.instanceId];
+        [[PowerAuthWCSessionManager sharedInstance] registerDataHandler:timeService];
+        _timeSynchronizationService = timeService;
+        
         // Prepare remote token provider, which is using WatchConnectivity internally
         _remoteProvider = [[PA2WatchRemoteTokenProvider alloc] init];
+        
         // Prepare keychain token store
         PowerAuthKeychainConfiguration * keychainConfiguration = [PowerAuthKeychainConfiguration sharedInstance];
         PowerAuthKeychain * tokenStoreKeychain = [[PowerAuthKeychain alloc] initWithIdentifier:keychainConfiguration.keychainInstanceName_TokenStore];
+        
         // ..and finally, create token store
         PA2PrivateTokenKeychainStore * tokenStore = [[PA2PrivateTokenKeychainStore alloc] initWithConfiguration:_configuration
                                                                                                        keychain:tokenStoreKeychain
                                                                                                  statusProvider:self
                                                                                                  remoteProvider:_remoteProvider
+                                                                                                    timeService:_timeSynchronizationService
                                                                                                        dataLock:self
                                                                                                       localLock:_lock];
         tokenStore.allowInMemoryCache = NO;

--- a/Sources/PowerAuth2ForWatch/private/PA2CompositeTask.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2CompositeTask.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <PowerAuth2ForWatch/PowerAuthOperationTask.h>
+
+/// The `PA2CompositeTask` allows you to execute multiple operation tasks as an one
+/// cancelable operation exposed to the application.
+@interface PA2CompositeTask : NSObject<PowerAuthOperationTask>
+
+/// Initialize object with optional cancel block.
+/// - Parameter cancelBlock: Optional cancel block called when operation is canceled.
+- (instancetype) initWithCancelBlock:(void(^)(void))cancelBlock;
+
+/// Replace underlying operation task with new task. If this composite task is already canceled, then
+/// the provided task is also canceled.
+/// - Parameter operationTask: New underlying task.
+/// - Returns: YES if composite operation is not canceled yet and task was replaced, otherwise NO.
+- (BOOL) replaceOperationTask:(id<PowerAuthOperationTask>)operationTask;
+
+/// Set operation as completed.
+/// - Returns: YES if composite operation is not canceled or completed yet.
+- (BOOL) setCompleted;
+
+@end

--- a/Sources/PowerAuth2ForWatch/private/PA2CompositeTask.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2CompositeTask.m
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2CompositeTask.h"
+
+@implementation PA2CompositeTask
+{
+    dispatch_semaphore_t _lock;
+    BOOL _isCancelled;
+    BOOL _isCompleted;
+    id<PowerAuthOperationTask> _operationTask;
+    void(^_cancelBlock)(void);
+}
+
+#define LOCK()      dispatch_semaphore_wait(_lock, DISPATCH_TIME_FOREVER)
+#define UNLOCK()    dispatch_semaphore_signal(_lock)
+
+- (instancetype) initWithCancelBlock:(void(^)(void))cancelBlock
+{
+    self = [super init];
+    if (self) {
+        _lock = dispatch_semaphore_create(1);
+        _cancelBlock = cancelBlock;
+    }
+    return self;
+}
+
+- (BOOL) isCancelled
+{
+    LOCK();
+    //
+    BOOL result = _isCancelled;
+    //
+    UNLOCK();
+    return result;
+}
+
+- (BOOL) isNotFinished
+{
+    return !(_isCancelled || _isCompleted);
+}
+
+- (void) cancel
+{
+    void(^cancelBlock)(void) = nil;
+    
+    LOCK();
+    //
+    if ([self isNotFinished]) {
+        _isCancelled = YES;
+        [_operationTask cancel];
+        _operationTask = nil;
+        cancelBlock = _cancelBlock;
+        _cancelBlock = nil;
+    }
+    //
+    UNLOCK();
+    
+    // Execute cancel block from outside of the lock to prevent
+    // a possible deadlock.
+    if (cancelBlock) {
+        cancelBlock();
+    }
+}
+
+- (BOOL) replaceOperationTask:(id<PowerAuthOperationTask>)operationTask
+{
+    LOCK();
+    //
+    BOOL result = [self isNotFinished];
+    if (result) {
+        _operationTask = operationTask;
+    } else {
+        [operationTask cancel];
+    }
+    //
+    UNLOCK();
+    return result;
+}
+
+- (BOOL) setCompleted
+{
+    LOCK();
+    //
+    BOOL result = [self isNotFinished];
+    _isCompleted = YES;
+    _cancelBlock = nil;
+    //
+    UNLOCK();
+    return result;
+}
+
+@end

--- a/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.h
@@ -19,6 +19,7 @@
 
 #import <PowerAuth2ForWatch/PowerAuthToken.h>
 #import <PowerAuth2ForWatch/PowerAuthSessionStatusProvider.h>
+#import <PowerAuth2ForWatch/PowerAuthTimeSynchronizationService.h>
 
 #import "PA2PrivateTokenInterfaces.h"
 #import "PA2PrivateRemoteTokenProvider.h"
@@ -53,6 +54,10 @@
  */
 @property (nonatomic, weak, readonly) id<PA2PrivateRemoteTokenProvider> remoteTokenProvider;
 /**
+ An associated time synchronization service.
+ */
+@property (nonatomic, weak, readonly) id<PowerAuthTimeSynchronizationService> timeSynchronizationService;
+/**
  If YES then in-memory cache will be used for access speedup.
  By default is YES for IOS and watchOS and NO for IOS extensions.
  */
@@ -73,6 +78,7 @@
                     keychain:(PowerAuthKeychain*)keychain
               statusProvider:(id<PowerAuthSessionStatusProvider>)statusProvider
               remoteProvider:(id<PA2PrivateRemoteTokenProvider>)remoteProvider
+                 timeService:(id<PowerAuthTimeSynchronizationService>)timeService
                     dataLock:(id<PA2TokenDataLock>)dataLock
                    localLock:(id<NSLocking>)localLock;
 

--- a/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.m
@@ -135,11 +135,34 @@
     [_tokenDataLock unlockTokenStore:modified];
 }
 
+/// Get strong reference to the time synchronization service. If weak reference is nil then report an error.
+/// - Parameter error: Pointer to store the failure.
+- (id<PowerAuthTimeSynchronizationService>) strongTimeSynchronizationService:(NSError**)error
+{
+    id service = _timeSynchronizationService;
+    if (!service) {
+        PA2SetError(error, PowerAuthErrorCode_OperationCancelled, @"Time synchronization service is no longer valid");
+    }
+    return service;
+}
+
+/// Get strong reference to the session status provided. If weak reference is nil then report an error.
+/// - Parameter error: Pointer to store the failure.
+- (id<PowerAuthSessionStatusProvider>) strongSessionStatusProvider:(NSError**)error
+{
+    id provider = _statusProvider;
+    if (!provider) {
+        PA2SetError(error, PowerAuthErrorCode_OperationCancelled, @"Session status provider is no longer valid");
+    }
+    return provider;
+}
+
 #pragma mark - PowerAuthPrivateTokenStore protocol
 
 - (BOOL) canGenerateHeaderForToken:(PowerAuthToken *)token
 {
-    return [_statusProvider hasValidActivation] && [_statusProvider.activationIdentifier isEqualToString:token.privateTokenData.activationIdentifier];
+    id<PowerAuthSessionStatusProvider> statusProvider = _statusProvider;
+    return [statusProvider hasValidActivation] && [statusProvider.activationIdentifier isEqualToString:token.privateTokenData.activationIdentifier];
 }
 
 - (void) storeTokenData:(PA2PrivateTokenData*)tokenData
@@ -179,11 +202,21 @@
 - (nullable PowerAuthHttpHeader*) calculateTokenHeader:(PA2PrivateTokenData *)tokenData
                                                  error:(NSError *_Nullable *_Nullable)error
 {
-    if (!_statusProvider.hasValidActivation) {
+    // Capture strong reference to the essential objects
+    id<PowerAuthTimeSynchronizationService> timeService = [self strongTimeSynchronizationService:error];
+    if (!timeService) {
+        return nil;
+    }
+    id<PowerAuthSessionStatusProvider> statusProvider = [self strongSessionStatusProvider:error];
+    if (!statusProvider) {
+        return nil;
+    }
+    
+    if (!statusProvider.hasValidActivation) {
         PA2SetError(error, PowerAuthErrorCode_MissingActivation, @"Activation is no longer valid");
         return nil;
     }
-    if (![_statusProvider.activationIdentifier isEqualToString:tokenData.activationIdentifier]) {
+    if (![statusProvider.activationIdentifier isEqualToString:tokenData.activationIdentifier]) {
         PA2SetError(error, PowerAuthErrorCode_InvalidToken, @"Activation for this token is no longer valid");
         return nil;
     }
@@ -192,14 +225,14 @@
         return nil;
     }
     
-    NSString * version = _statusProvider.powerAuthProtocolVersion;
-    NSString * algorithm = _statusProvider.powerAuthAlgorithm;
+    NSString * version = statusProvider.powerAuthProtocolVersion;
+    NSString * algorithm = statusProvider.powerAuthAlgorithm;
     if (!version || !algorithm) {
         PA2SetError(error, PowerAuthErrorCode_Other, @"Protocol version or algorithm is unavailable in token calculation");
         return nil;
     }
-    
-    if (!_timeSynchronizationService.isTimeSynchronized) {
+    if (!timeService.isTimeSynchronized) {
+        // This will be replaced with strict error in some future version of SDK.
         PowerAuthLog(@"WARNING: Time is not synchronized before token header calculation");
     }
 
@@ -207,7 +240,7 @@
     NSString * tokenIdentifier = tokenData.identifier;
 
     // Prepare data for HMAC
-    NSNumber * currentTimeMs = @((int64_t)([_timeSynchronizationService currentTime] * 1000));
+    NSNumber * currentTimeMs = @((int64_t)([timeService currentTime] * 1000));
     NSString * currentTimeString = [currentTimeMs stringValue];
     NSData * currentTimeData = [currentTimeString dataUsingEncoding:NSASCIIStringEncoding];
     NSData * versionData = [version dataUsingEncoding:NSASCIIStringEncoding];
@@ -286,17 +319,22 @@
         }
         return nil;
     }
+    NSError * error = nil;
+    id<PowerAuthSessionStatusProvider> statusProvider = [self strongSessionStatusProvider:&error];
+    if (!statusProvider) {
+        completion(nil, error);
+        return nil;
+    }
     BOOL authenticationIsRequired = [_remoteTokenProvider authenticationIsRequired];
     if (!authentication && authenticationIsRequired) {
         completion(nil, PA2MakeError(PowerAuthErrorCode_WrongParameter, @"Authentication object is missing."));
         return nil;
     }
-    if (!_statusProvider.hasValidActivation) {
+    if (!statusProvider.hasValidActivation) {
         completion(nil, PA2MakeError(PowerAuthErrorCode_MissingActivation, @"Activation is no longer valid."));
         return nil;
     }
     
-    NSError * error = nil;
     PA2PrivateTokenData * tokenData = [self tokenDataForTokenName:name authentication:authentication error:&error];
     if (tokenData || error) {
         // The data is available, so the token can be returned synchronously
@@ -331,7 +369,7 @@
             groupTask = [[PA2CreateTokenTask alloc] initWithProvider:strongTokenProvider
                                                           tokenStore:self
                                                       authentication:authentication
-                                                        activationId:_statusProvider.activationIdentifier
+                                                        activationId:statusProvider.activationIdentifier
                                                            tokenName:name
                                                           sharedLock:_localLock];
             // Keep group task in the dictionary.
@@ -359,11 +397,16 @@
         }
         return nil;
     }
-    if (!_statusProvider.hasValidActivation) {
+    NSError * error = nil;
+    id<PowerAuthSessionStatusProvider> statusProvider = [self strongSessionStatusProvider:&error];
+    if (!statusProvider) {
+        completion(NO, error);
+        return nil;
+    }
+    if (!statusProvider.hasValidActivation) {
         completion(NO, PA2MakeError(PowerAuthErrorCode_MissingActivation, @"Activation is no longer valid."));
         return nil;
     }
-    NSError * error = nil;
     PA2PrivateTokenData * tokenData = [self tokenDataForTokenName:name authentication:nil error:&error];
     if (!tokenData) {
         completion(NO, error ? error : PA2MakeError(PowerAuthErrorCode_InvalidToken, @"Token not found."));
@@ -435,23 +478,27 @@
         PowerAuthHttpHeader * header = nil;
         BOOL completeOperation = YES;
         if (token) {
-            if (_timeSynchronizationService.isTimeSynchronized) {
-                // Time is synchronized, so it's safe to calculate token.
-                header = [self calculateTokenHeader:token.privateTokenData error:&error];
-            } else {
-                // Time is not synchronized.
-                id<PowerAuthOperationTask> timeSyncTask = [_timeSynchronizationService synchronizeTimeWithCallback:^(NSError * _Nullable error) {
-                    PowerAuthHttpHeader * header = nil;
-                    if (!error) {
-                        // Time successfully synchronized
-                        header = [self calculateTokenHeader:token.privateTokenData error:&error];
-                    }
-                    // Operation can be finally completed
-                    completeCompositeTask(header, error);
-                } callbackQueue:nil];
-                [compositeTask replaceOperationTask:timeSyncTask];
-                // Operation cannot be completed yet
-                completeOperation = NO;
+            // Capture strong reference to time service
+            id<PowerAuthTimeSynchronizationService> timeService = [self strongTimeSynchronizationService:&error];
+            if (timeService) {
+                if (timeService.isTimeSynchronized) {
+                    // Time is synchronized, so it's safe to calculate token.
+                    header = [self calculateTokenHeader:token.privateTokenData error:&error];
+                } else {
+                    // Time is not synchronized.
+                    id<PowerAuthOperationTask> timeSyncTask = [timeService synchronizeTimeWithCallback:^(NSError * _Nullable error) {
+                        PowerAuthHttpHeader * header = nil;
+                        if (!error) {
+                            // Time successfully synchronized
+                            header = [self calculateTokenHeader:token.privateTokenData error:&error];
+                        }
+                        // Operation can be finally completed
+                        completeCompositeTask(header, error);
+                    } callbackQueue:nil];
+                    [compositeTask replaceOperationTask:timeSyncTask];
+                    // Operation cannot be completed yet
+                    completeOperation = NO;
+                }
             }
         }
         // Complete task if result is already known

--- a/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.m
@@ -25,6 +25,7 @@
 #import "PowerAuthAuthentication+Private.h"
 #import "PowerAuthHttpHeader+Private.h"
 #import "PA2CoreCryptoUtils.h"
+#import "PA2CompositeTask.h"
 
 #import <PowerAuth2ForWatch/PowerAuthErrorConstants.h>
 #import <PowerAuth2ForWatch/PowerAuthKeychain.h>
@@ -54,6 +55,7 @@
                     keychain:(PowerAuthKeychain*)keychain
               statusProvider:(id<PowerAuthSessionStatusProvider>)statusProvider
               remoteProvider:(id<PA2PrivateRemoteTokenProvider>)remoteProvider
+                 timeService:(id<PowerAuthTimeSynchronizationService>)timeService
                     dataLock:(id<PA2TokenDataLock>)dataLock
                    localLock:(id<NSLocking>)localLock
 {
@@ -62,6 +64,7 @@
         _sdkConfiguration = configuration;
         _statusProvider = statusProvider;
         _remoteTokenProvider = remoteProvider;
+        _timeSynchronizationService = timeService;
         _keychain = keychain;
         _tokenDataLock = dataLock;
         _localLock = localLock ? localLock : [[NSRecursiveLock alloc] init];
@@ -416,14 +419,44 @@
 - (nullable id<PowerAuthOperationTask>) generateAuthenticationHeaderWithName:(nonnull NSString *)name
                                                                   completion:(nonnull void (^)(PowerAuthHttpHeader * _Nullable, NSError * _Nullable))completion
 {
-    // TODO: implement time synchronization
-    return [self requestAccessTokenImpl:name authentication:nil completion:^(PowerAuthToken *token, NSError *error) {
-        PowerAuthHttpHeader * header = nil;
-        if (token) {
-            header = [self calculateTokenHeader:token.privateTokenData error:&error];
+    // Composite task and its completion closure
+    PA2CompositeTask * compositeTask = [[PA2CompositeTask alloc] initWithCancelBlock:nil];
+    void (^completeCompositeTask)(PowerAuthHttpHeader *, NSError *) = ^(PowerAuthHttpHeader * header, NSError * error) {
+        if ([compositeTask setCompleted]) {
+            completion(header, error);
         }
-        completion(header, error);
+    };
+    // Request for token
+    id<PowerAuthOperationTask> requestTask = [self requestAccessTokenImpl:name authentication:nil completion:^(PowerAuthToken *token, NSError *error) {
+        PowerAuthHttpHeader * header = nil;
+        BOOL completeOperation = YES;
+        if (token) {
+            if (_timeSynchronizationService.isTimeSynchronized) {
+                // Time is synchronized, so it's safe to calculate token.
+                header = [self calculateTokenHeader:token.privateTokenData error:&error];
+            } else {
+                // Time is not synchronized.
+                id<PowerAuthOperationTask> timeSyncTask = [_timeSynchronizationService synchronizeTimeWithCallback:^(NSError * _Nullable error) {
+                    PowerAuthHttpHeader * header = nil;
+                    if (!error) {
+                        // Time successfully synchronized
+                        header = [self calculateTokenHeader:token.privateTokenData error:&error];
+                    }
+                    // Operation can be finally completed
+                    completeCompositeTask(header, error);
+                } callbackQueue:nil];
+                [compositeTask replaceOperationTask:timeSyncTask];
+                // Operation cannot be completed yet
+                completeOperation = NO;
+            }
+        }
+        // Complete task if result is already known
+        if (completeOperation) {
+            completeCompositeTask(header, error);
+        }
     }];
+    [compositeTask replaceOperationTask:requestTask];
+    return compositeTask;
 }
 
 

--- a/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2PrivateTokenKeychainStore.m
@@ -198,12 +198,16 @@
         PA2SetError(error, PowerAuthErrorCode_Other, @"Protocol version or algorithm is unavailable in token calculation");
         return nil;
     }
+    
+    if (!_timeSynchronizationService.isTimeSynchronized) {
+        PowerAuthLog(@"WARNING: Time is not synchronized before token header calculation");
+    }
 
     NSData * tokenSecret = tokenData.secret;
     NSString * tokenIdentifier = tokenData.identifier;
 
     // Prepare data for HMAC
-    NSNumber * currentTimeMs = @((int64_t)([[NSDate date] timeIntervalSince1970] * 1000));
+    NSNumber * currentTimeMs = @((int64_t)([_timeSynchronizationService currentTime] * 1000));
     NSString * currentTimeString = [currentTimeMs stringValue];
     NSData * currentTimeData = [currentTimeString dataUsingEncoding:NSASCIIStringEncoding];
     NSData * versionData = [version dataUsingEncoding:NSASCIIStringEncoding];

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.h
@@ -32,37 +32,37 @@
 @property (nonatomic, readonly) BOOL delayedCompletion;
 
 /// Contains response packet or `nil` if response is not available yet.
-@property (nonatomic, readonly, strong) PA2WCSessionPacket * responsePacket;
+@property (nonatomic, readonly, strong, nullable) PA2WCSessionPacket * responsePacket;
 
 /// Create instance of response object for asynchronous reply. The response
 /// packet will be provided later, after the asynchronous operation is finished.
-+ (instancetype) asyncResponse;
++ (nonnull instancetype) asyncResponse;
 
 /// Create instance of response object with the response packet.
 /// - Parameter responsePacket: Packet for response.
-+ (instancetype) responseWithPacket:(PA2WCSessionPacket*)responsePacket;
++ (nonnull instancetype) responseWithPacket:(nonnull PA2WCSessionPacket*)responsePacket;
 
 /// Create instance of response object with the error.
 /// - Parameter error: Error to send as response.
-+ (instancetype) responseWithError:(NSError*)error;
++ (nonnull instancetype) responseWithError:(nonnull NSError*)error;
 
 /// Create instance of response object with the error message. The error code
 /// is set to `PowerAuthErrorCode_WatchConnectivity`.
 /// - Parameter errorMessage: Error message to send as response.
-+ (instancetype) responseWithErrorMessage:(NSString*)errorMessage;
++ (nonnull instancetype) responseWithErrorMessage:(nonnull NSString*)errorMessage;
 
 /// Set completion callback for asynchronous reply. The callback is called immediately
 /// when the response is completed with packet or with error.
 /// - Parameter completionCallback: Completion callback.
-- (void) setCompletionCallback:(void(^)(PA2WCSessionPacket * response))completionCallback;
+- (void) setCompletionCallback:(void(^_Nonnull)(PA2WCSessionPacket * _Nonnull response))completionCallback;
 
 /// Complete asynchronous response with response packet.
 /// - Parameter responsePacket: Response packet to use for reply.
-- (void) completeWithResponsePacket:(PA2WCSessionPacket*)responsePacket;
+- (void) completeWithResponsePacket:(nonnull PA2WCSessionPacket*)responsePacket;
 
 /// Complete asynchronous response with error.
 /// - Parameter error: Error to use for reply.
-- (void) completeWithError:(NSError*)error;
+- (void) completeWithError:(nonnull NSError*)error;
 
 @end
 
@@ -76,14 +76,14 @@
 /**
  Implementation must return YES, if packet can be processed in this handler.
  */
-- (BOOL) canProcessPacket:(PA2WCSessionPacket*)packet;
+- (BOOL) canProcessPacket:(nonnull PA2WCSessionPacket*)packet;
 
 /**
  Implementation must always return response for given packet. The PA2WCSessionManager is calling
  this method only for handler which can process the packet (e.g. canProcessPacket was called before
  and method returned YES)
  */
-- (PA2WCSessionDataHandlerResponse*) sessionManager:(PowerAuthWCSessionManager*)manager responseForPacket:(PA2WCSessionPacket*)packet;
+- (nonnull PA2WCSessionDataHandlerResponse*) sessionManager:(nonnull PowerAuthWCSessionManager*)manager responseForPacket:(nonnull PA2WCSessionPacket*)packet;
 
 @end
 

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.h
@@ -24,6 +24,48 @@
 
 @class PowerAuthWCSessionManager;
 
+/// The `PA2WCSessionDataHandlerResponse` class contains packet for response
+/// produced in `PA2WCSessionDataHandler` implementation.
+@interface PA2WCSessionDataHandlerResponse : NSObject
+
+/// Contains `YES` if this response is asynchronous due to a delayed completion.
+@property (nonatomic, readonly) BOOL delayedCompletion;
+
+/// Contains response packet or `nil` if response is not available yet.
+@property (nonatomic, readonly, strong) PA2WCSessionPacket * responsePacket;
+
+/// Create instance of response object for asynchronous reply. The response
+/// packet will be provided later, after the asynchronous operation is finished.
++ (instancetype) asyncResponse;
+
+/// Create instance of response object with the response packet.
+/// - Parameter responsePacket: Packet for response.
++ (instancetype) responseWithPacket:(PA2WCSessionPacket*)responsePacket;
+
+/// Create instance of response object with the error.
+/// - Parameter error: Error to send as response.
++ (instancetype) responseWithError:(NSError*)error;
+
+/// Create instance of response object with the error message. The error code
+/// is set to `PowerAuthErrorCode_WatchConnectivity`.
+/// - Parameter errorMessage: Error message to send as response.
++ (instancetype) responseWithErrorMessage:(NSString*)errorMessage;
+
+/// Set completion callback for asynchronous reply. The callback is called immediately
+/// when the response is completed with packet or with error.
+/// - Parameter completionCallback: Completion callback.
+- (void) setCompletionCallback:(void(^)(PA2WCSessionPacket * response))completionCallback;
+
+/// Complete asynchronous response with response packet.
+/// - Parameter responsePacket: Response packet to use for reply.
+- (void) completeWithResponsePacket:(PA2WCSessionPacket*)responsePacket;
+
+/// Complete asynchronous response with error.
+/// - Parameter error: Error to use for reply.
+- (void) completeWithError:(NSError*)error;
+
+@end
+
 /**
  The PA2WCSessionDataHandler protocol defines interface for processing packets
  transmitted between Apple Watch and iPhone.
@@ -41,7 +83,7 @@
  this method only for handler which can process the packet (e.g. canProcessPacket was called before
  and method returned YES)
  */
-- (PA2WCSessionPacket*) sessionManager:(PowerAuthWCSessionManager*)manager responseForPacket:(PA2WCSessionPacket*)packet;
+- (PA2WCSessionDataHandlerResponse*) sessionManager:(PowerAuthWCSessionManager*)manager responseForPacket:(PA2WCSessionPacket*)packet;
 
 @end
 

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.m
@@ -62,7 +62,7 @@
         if (_delayedCompletion && !_completionCallback) {
             if (_responsePacket) {
                 // Response is already known
-                packetToReport = packetToReport;
+                packetToReport = _responsePacket;
             } else {
                 // Otherwise keep callback for later
                 _completionCallback = completionCallback;

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.m
@@ -58,16 +58,24 @@
 - (void) setCompletionCallback:(void (^)(PA2WCSessionPacket *))completionCallback
 {
     if (_delayedCompletion && !_completionCallback) {
-        _completionCallback = completionCallback;
+        if (_responsePacket) {
+            // Response is already known
+            completionCallback(_responsePacket);
+        } else {
+            // Otherwise keep callback for later
+            _completionCallback = completionCallback;
+        }
     }
 }
 
 - (void) completeWithResponsePacket:(PA2WCSessionPacket *)responsePacket
 {
-    if (_delayedCompletion && _completionCallback) {
+    if (_delayedCompletion && !_responsePacket) {
         _responsePacket = responsePacket;
-        _completionCallback(responsePacket);
-        _completionCallback = nil;
+        if (_completionCallback) {
+            _completionCallback(responsePacket);
+            _completionCallback = nil;
+        }
     }
 }
 

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.m
@@ -57,25 +57,39 @@
 
 - (void) setCompletionCallback:(void (^)(PA2WCSessionPacket *))completionCallback
 {
-    if (_delayedCompletion && !_completionCallback) {
-        if (_responsePacket) {
-            // Response is already known
-            completionCallback(_responsePacket);
-        } else {
-            // Otherwise keep callback for later
-            _completionCallback = completionCallback;
+    PA2WCSessionPacket * packetToReport = nil;
+    @synchronized (self) {
+        if (_delayedCompletion && !_completionCallback) {
+            if (_responsePacket) {
+                // Response is already known
+                packetToReport = packetToReport;
+            } else {
+                // Otherwise keep callback for later
+                _completionCallback = completionCallback;
+            }
         }
+    }
+    // Complete outside of locked section.
+    if (packetToReport && completionCallback) {
+        completionCallback(packetToReport);
     }
 }
 
 - (void) completeWithResponsePacket:(PA2WCSessionPacket *)responsePacket
 {
-    if (_delayedCompletion && !_responsePacket) {
-        _responsePacket = responsePacket;
-        if (_completionCallback) {
-            _completionCallback(responsePacket);
-            _completionCallback = nil;
+    void(^completionCallback)(PA2WCSessionPacket * response) = nil;
+    @synchronized (self) {
+        if (_delayedCompletion && !_responsePacket) {
+            _responsePacket = responsePacket;
+            if (_completionCallback) {
+                completionCallback = _completionCallback;
+                _completionCallback = nil;
+            }
         }
+    }
+    // Complete outside of locked section.
+    if (completionCallback) {
+        completionCallback(responsePacket);
     }
 }
 

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionDataHandler.m
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2WCSessionDataHandler.h"
+#import "PA2PrivateMacros.h"
+
+#if defined(PA2_WATCH_SUPPORT)
+
+@implementation PA2WCSessionDataHandlerResponse
+{
+    void(^_completionCallback)(PA2WCSessionPacket * response);
+}
+
+- (instancetype) initWithResponsePacket:(PA2WCSessionPacket *)responsePacket
+{
+    self = [super init];
+    if (self) {
+        _responsePacket = responsePacket;
+        _delayedCompletion = responsePacket == nil;
+    }
+    return self;
+}
+
++ (instancetype) asyncResponse
+{
+    return [[PA2WCSessionDataHandlerResponse alloc] initWithResponsePacket:nil];
+}
+
++ (instancetype) responseWithPacket:(PA2WCSessionPacket*)responsePacket
+{
+    return [[PA2WCSessionDataHandlerResponse alloc] initWithResponsePacket:responsePacket];
+}
+
++ (instancetype) responseWithError:(NSError*)error
+{
+    return [self responseWithPacket:[PA2WCSessionPacket packetWithError:error]];
+}
+
++ (instancetype) responseWithErrorMessage:(NSString*)errorMessage
+{
+    NSError * error = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, errorMessage);
+    return [self responseWithPacket:[PA2WCSessionPacket packetWithError:error]];
+}
+
+- (void) setCompletionCallback:(void (^)(PA2WCSessionPacket *))completionCallback
+{
+    if (_delayedCompletion && !_completionCallback) {
+        _completionCallback = completionCallback;
+    }
+}
+
+- (void) completeWithResponsePacket:(PA2WCSessionPacket *)responsePacket
+{
+    if (_delayedCompletion && _completionCallback) {
+        _responsePacket = responsePacket;
+        _completionCallback(responsePacket);
+        _completionCallback = nil;
+    }
+}
+
+- (void) completeWithError:(NSError *)error
+{
+    [self completeWithResponsePacket:[PA2WCSessionPacket packetWithError:error]];
+}
+
+@end
+
+#endif // defined(PA2_WATCH_SUPPORT)

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket.m
@@ -94,16 +94,4 @@
     return self;
 }
 
-- (BOOL) deserializePayloadForClass:(Class)aClass
-{
-    if (!_error && _sourceData) {
-        id instance = [[aClass alloc] initWithDictionary:_sourceData];
-        if ([instance conformsToProtocol:@protocol(PA2WCSessionPacketData)]) {
-            _payload = instance;
-            return YES;
-        }
-    }
-    return NO;
-}
-
 @end

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_Constants.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_Constants.h
@@ -18,7 +18,7 @@
 
 #import <PowerAuth2ForWatch/PowerAuthMacros.h>
 
-// Key used in userInfo, transmitted over the
+// Key used in userInfo, transmitted over the WatchConnectivity.
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_USER_INFO_KEY;
 
 // value for "target" property, when response is transmitted.

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_Constants.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_Constants.h
@@ -18,11 +18,13 @@
 
 #import <PowerAuth2ForWatch/PowerAuthMacros.h>
 
-// Key used in userInfo
+// Key used in userInfo, transmitted over the
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_USER_INFO_KEY;
 
 // value for "target" property, when response is transmitted.
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_RESPONSE_TARGET;
+// Prefix for all time service related messages.
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_TIME_SERVICE_TARGET;
 // Prefix for all session related messages
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_SESSION_TARGET;
 // Prefix for all token related messages
@@ -51,6 +53,15 @@ PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_TOKEN_NA;
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_CMD_TOKEN_GET;
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_CMD_TOKEN_PUT;
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_CMD_TOKEN_REMOVE;
+
+// Constants for serializing service related data
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_TIME_SERVICE_CMD;
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_TIME_SERVICE_LOCAL;
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_TIME_SERVICE_DELTA;
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_TIME_SERVICE_PRECISION;
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_CMD_TIME_SERVICE_GET;
+PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_CMD_TIME_SERVICE_PUT;
+
 
 // Generic success
 PA2_EXTERN_C NSString * __nonnull const PA2WCSessionPacket_KEY_SUCCESS;

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_Constants.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_Constants.m
@@ -23,6 +23,9 @@ PA2_NO_EXPORT NSString * const PA2WCSessionPacket_USER_INFO_KEY       = @"com.wu
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_RESPONSE_TARGET     = @"*";
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_SESSION_TARGET      = @"session:";
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_TOKEN_TARGET        = @"token:";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_TIME_SERVICE_TARGET = @"time:";
+
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_SUCCESS         = @"successCode";
 
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_TARGET          = @"target";
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_ERROR_CODE      = @"errorCode";
@@ -44,4 +47,9 @@ PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_TOKEN_GET       = @"get_to
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_TOKEN_PUT       = @"put_token";
 PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_TOKEN_REMOVE    = @"remove_token";
 
-PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_SUCCESS         = @"successCode";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_TIME_SERVICE_CMD       = @"timeCmd";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_TIME_SERVICE_LOCAL     = @"timeLocal";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_TIME_SERVICE_DELTA     = @"timeDelta";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_KEY_TIME_SERVICE_PRECISION = @"timePrecision";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_TIME_SERVICE_GET       = @"get_time";
+PA2_NO_EXPORT NSString * const PA2WCSessionPacket_CMD_TIME_SERVICE_PUT       = @"put_time";

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_TimeSync.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_TimeSync.h
@@ -23,7 +23,7 @@
 /// Supported commands:
 /// - PA2WCSessionPacket_CMD_TIME_SERVICE_GET - when watchOS is asking for synchronized time.
 ///   - response is PA2WCSessionPacket_CMD_TIME_SERVICE_PUT
-/// - PA2WCSessionPacket_CMD_TIME_SERVICE_PUT - when IOS wants to send information about synchronized time to watchOS.
+/// - PA2WCSessionPacket_CMD_TIME_SERVICE_PUT - when iOS wants to send information about synchronized time to watchOS.
 ///   - response is "Success" packet
 @property (nonatomic, strong) NSString * command;
 

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_TimeSync.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_TimeSync.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2WCSessionPacket.h"
+
+/// The `PA2WCSessionPacket_TimeSync` contains information required for
+/// the time synchronization on watchOS.
+@interface PA2WCSessionPacket_TimeSync : NSObject<PA2WCSessionPacketData>
+
+/// Supported commands:
+/// - PA2WCSessionPacket_CMD_TIME_SERVICE_GET - when watchOS is asking for synchronized time.
+///   - response is PA2WCSessionPacket_CMD_TIME_SERVICE_PUT
+/// - PA2WCSessionPacket_CMD_TIME_SERVICE_PUT - when IOS wants to send information about synchronized time to watchOS.
+///   - response is "Success" packet
+@property (nonatomic, strong) NSString * command;
+
+/// Contains current time on iOS, synchronized with the server.
+@property (nonatomic, assign) NSTimeInterval localTime;
+/// Contains calculated local time difference against the server.
+@property (nonatomic, assign) NSTimeInterval localTimeAdjustment;
+/// Contains value representing a maximum absolute deviation of synchronized time against the actual time on the server.
+@property (nonatomic, assign) NSTimeInterval localTimeAdjustmentPrecision;
+
+@end

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_TimeSync.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_TimeSync.m
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2WCSessionPacket_TimeSync.h"
+#import "PA2PrivateMacros.h"
+
+@implementation PA2WCSessionPacket_TimeSync
+
+static inline NSTimeInterval _ValueToInterval(id value)
+{
+    if ([value isKindOfClass:[NSNumber class]]) {
+        return [(NSNumber*)value doubleValue];
+    }
+    return 0.0;
+}
+
+static inline BOOL _IsValidInterval(NSTimeInterval interval, BOOL allow_negative)
+{
+    if (isnan(interval)) {
+        return NO;
+    }
+    return allow_negative || interval >= 0.0;
+}
+
+- (id) initWithDictionary:(NSDictionary *)dictionary
+{
+    self = [super init];
+    if (self) {
+        _command = PA2ObjectAs(dictionary[PA2WCSessionPacket_KEY_TIME_SERVICE_CMD], NSString);
+        _localTime = _ValueToInterval(dictionary[PA2WCSessionPacket_KEY_TIME_SERVICE_LOCAL]);
+        _localTimeAdjustment = _ValueToInterval(dictionary[PA2WCSessionPacket_KEY_TIME_SERVICE_DELTA]);
+        _localTimeAdjustmentPrecision = _ValueToInterval(dictionary[PA2WCSessionPacket_KEY_TIME_SERVICE_PRECISION]);
+    }
+    return self;
+}
+
+- (void) serializeToDictionary:(NSMutableDictionary *)dictionary
+{
+    if (_command) {
+        dictionary[PA2WCSessionPacket_KEY_TIME_SERVICE_CMD] = _command;
+    }
+    dictionary[PA2WCSessionPacket_KEY_TIME_SERVICE_LOCAL]     = @(_localTime);
+    dictionary[PA2WCSessionPacket_KEY_TIME_SERVICE_DELTA]     = @(_localTimeAdjustment);
+    dictionary[PA2WCSessionPacket_KEY_TIME_SERVICE_PRECISION] = @(_localTimeAdjustmentPrecision);
+}
+
+- (BOOL) validatePacketData
+{
+    return ([_command isEqualToString:PA2WCSessionPacket_CMD_TIME_SERVICE_GET] ||
+            [_command isEqualToString:PA2WCSessionPacket_CMD_TIME_SERVICE_PUT]) &&
+            _IsValidInterval(_localTime, NO) &&
+            _IsValidInterval(_localTimeAdjustment, YES) &&
+            _IsValidInterval(_localTimeAdjustmentPrecision, NO);
+}
+
+@end

--- a/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_TimeSync.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WCSessionPacket_TimeSync.m
@@ -29,10 +29,10 @@ static inline NSTimeInterval _ValueToInterval(id value)
 
 static inline BOOL _IsValidInterval(NSTimeInterval interval, BOOL allow_negative)
 {
-    if (isnan(interval)) {
-        return NO;
+    if (isfinite(interval)) {
+        return allow_negative || interval >= 0.0;
     }
-    return allow_negative || interval >= 0.0;
+    return NO;
 }
 
 - (id) initWithDictionary:(NSDictionary *)dictionary

--- a/Sources/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WatchSynchronizationService.m
@@ -140,21 +140,20 @@
            [packet.target hasPrefix:PA2WCSessionPacket_TOKEN_TARGET];
 }
 
-- (PA2WCSessionPacket*) sessionManager:(PowerAuthWCSessionManager*)manager responseForPacket:(PA2WCSessionPacket*)packet
+- (PA2WCSessionDataHandlerResponse*) sessionManager:(PowerAuthWCSessionManager*)manager responseForPacket:(PA2WCSessionPacket*)packet
 {
     if ([packet.target hasPrefix:PA2WCSessionPacket_SESSION_TARGET]) {
         return [self processSessionStatusPacket:packet];
     } else if ([packet.target hasPrefix:PA2WCSessionPacket_TOKEN_TARGET]) {
         return [self processTokenPacket:packet];
     }
-    NSError * error = PA2MakeError(PowerAuthErrorCode_WatchConnectivity, @"PA2WatchSynchronizationService: Can't process packet.");
-    return [PA2WCSessionPacket packetWithError:error];
+    return [PA2WCSessionDataHandlerResponse responseWithErrorMessage:@"PA2WatchSynchronizationService: Can't process packet."];
 }
 
 
 #pragma mark -
 
-- (PA2WCSessionPacket*) processSessionStatusPacket:(PA2WCSessionPacket*)packet
+- (PA2WCSessionDataHandlerResponse*) processSessionStatusPacket:(PA2WCSessionPacket*)packet
 {
     // Handle status packet received from iPhone
     NSString * errorMessage = nil;
@@ -186,15 +185,14 @@
     
     if (errorMessage) {
         // Return reply packet with error.
-        NSError * error = [NSError errorWithDomain:PowerAuthErrorDomain code:PowerAuthErrorCode_WatchConnectivity userInfo:@{ NSLocalizedDescriptionKey: errorMessage }];
-        return [PA2WCSessionPacket packetWithError:error];
+        return [PA2WCSessionDataHandlerResponse responseWithErrorMessage:errorMessage];
     }
     // Everything looks great, return Success packet.
-    return [PA2WCSessionPacket packetWithSuccess];
+    return [PA2WCSessionDataHandlerResponse responseWithPacket:[PA2WCSessionPacket packetWithSuccess]];
 }
 
 
-- (PA2WCSessionPacket*) processTokenPacket:(PA2WCSessionPacket*)packet
+- (PA2WCSessionDataHandlerResponse*) processTokenPacket:(PA2WCSessionPacket*)packet
 {
     NSString * errorMessage = nil;
     do {
@@ -243,13 +241,10 @@
 
     if (errorMessage) {
         // Return reply packet with error.
-        NSError * error = [NSError errorWithDomain:PowerAuthErrorDomain code:PowerAuthErrorCode_WatchConnectivity userInfo:@{ NSLocalizedDescriptionKey: errorMessage }];
-        return [PA2WCSessionPacket packetWithError:error];
+        return [PA2WCSessionDataHandlerResponse responseWithErrorMessage:errorMessage];
     }
     // Everything looks great, return Success packet.
-    return [PA2WCSessionPacket packetWithSuccess];
+    return [PA2WCSessionDataHandlerResponse responseWithPacket:[PA2WCSessionPacket packetWithSuccess]];
 }
-
-
 
 @end

--- a/Sources/PowerAuth2ForWatch/private/PA2WatchTimeSynchronizationService.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WatchTimeSynchronizationService.h
@@ -17,8 +17,11 @@
 #import <PowerAuth2ForWatch/PowerAuthTimeSynchronizationService.h>
 #import "PA2WCSessionDataHandler.h"
 
+/// Time synchronization service for watchOS.
 @interface PA2WatchTimeSynchronizationService : NSObject<PowerAuthTimeSynchronizationService, PA2WCSessionDataHandler>
 
+/// Construct service with instance identifier.
+/// - Parameter instanceId: Instance identifier.
 - (nonnull instancetype) initWithInstanceId:(nonnull NSString*)instanceId;
 
 @end

--- a/Sources/PowerAuth2ForWatch/private/PA2WatchTimeSynchronizationService.h
+++ b/Sources/PowerAuth2ForWatch/private/PA2WatchTimeSynchronizationService.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Wultra s.r.o.
+ * Copyright 2026 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-#import <PowerAuth2ForWatch/PowerAuthHttpHeader.h>
+#import <PowerAuth2ForWatch/PowerAuthTimeSynchronizationService.h>
+#import "PA2WCSessionDataHandler.h"
 
-@interface PowerAuthHttpHeader (Private)
+@interface PA2WatchTimeSynchronizationService : NSObject<PowerAuthTimeSynchronizationService, PA2WCSessionDataHandler>
 
-/// Private constructor for header object construction.
-/// - Parameters:
-///   - key: HTTP header name.
-///   - value: HTTP header value.
-- (nonnull instancetype) initWithKey:(nonnull NSString*)key
-                               value:(nonnull NSString*)value;
+- (nonnull instancetype) initWithInstanceId:(nonnull NSString*)instanceId;
 
 @end

--- a/Sources/PowerAuth2ForWatch/private/PA2WatchTimeSynchronizationService.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WatchTimeSynchronizationService.m
@@ -117,7 +117,9 @@
 
 - (BOOL) processReceivedPacket:(PA2WCSessionPacket*)packet error:(NSError**)error
 {
-    if (![packet.target isEqualToString:_target]) {
+    NSString * target = packet.target;
+    if (![target isEqualToString:_target] && ![target isEqualToString:PA2WCSessionPacket_RESPONSE_TARGET]) {
+        // Internal error in previous processing.
         PA2SetError(error, PowerAuthErrorCode_Other, @"Wrong target in processReceivedPacket function");
         return NO;
     }

--- a/Sources/PowerAuth2ForWatch/private/PA2WatchTimeSynchronizationService.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WatchTimeSynchronizationService.m
@@ -88,7 +88,7 @@
     PA2WCSessionPacket * packet = [PA2WCSessionPacket packetWithData:packetData target:_target];
     
     // Send packet with asynchronous response processing
-    [[PowerAuthWCSessionManager sharedInstance] sendPacketWithResponse:packet responseClass:[PA2WCSessionPacket_Success class] completion:^(PA2WCSessionPacket *response, NSError *error) {
+    [[PowerAuthWCSessionManager sharedInstance] sendPacketWithResponse:packet responseClass:[PA2WCSessionPacket_TimeSync class] completion:^(PA2WCSessionPacket *response, NSError *error) {
         if (response) {
             [self processReceivedPacket:response error:&error];
         }

--- a/Sources/PowerAuth2ForWatch/private/PA2WatchTimeSynchronizationService.m
+++ b/Sources/PowerAuth2ForWatch/private/PA2WatchTimeSynchronizationService.m
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PA2WatchTimeSynchronizationService.h"
+
+#import "PA2PrivateMacros.h"
+#import "PA2WCSessionPacket_TimeSync.h"
+#import "PA2WCSessionPacket_Success.h"
+#import "PA2CompositeTask.h"
+#import "PowerAuthWCSessionManager+Private.h"
+
+#import <PowerAuth2ForWatch/PowerAuthLog.h>
+
+
+@implementation PA2WatchTimeSynchronizationService
+{
+    NSString * _target;
+    BOOL _isTimeSynchronized;
+    NSTimeInterval _localTimeAdjustment;
+    NSTimeInterval _localTimeAdjustmentPrecision;
+}
+
+- (instancetype) initWithInstanceId:(NSString *)instanceId
+{
+    self = [super init];
+    if (self) {
+        _target = [PA2WCSessionPacket_TIME_SERVICE_TARGET stringByAppendingString:instanceId];
+        _isTimeSynchronized = NO;
+        _localTimeAdjustment = 0.0;
+        _localTimeAdjustmentPrecision = 0.0;
+    }
+    return self;
+}
+
+- (BOOL) isTimeSynchronized
+{
+    @synchronized (self) {
+        return _isTimeSynchronized;
+    }
+}
+
+- (NSTimeInterval) localTimeAdjustment
+{
+    @synchronized (self) {
+        return _localTimeAdjustment;
+    }
+}
+
+- (NSTimeInterval) localTimeAdjustmentPrecision
+{
+    @synchronized (self) {
+        return _localTimeAdjustmentPrecision;
+    }
+}
+
+- (NSTimeInterval) currentTime
+{
+    @synchronized (self) {
+        return [[NSDate date] timeIntervalSince1970] + _localTimeAdjustment;
+    }
+}
+
+- (id<PowerAuthOperationTask>) synchronizeTimeWithCallback:(void (^)(NSError * error))callback
+                                             callbackQueue:(dispatch_queue_t)callbackQueue
+{
+    if (!callbackQueue) {
+        callbackQueue = dispatch_get_main_queue();
+    }
+    // Prepare operation task
+    PA2CompositeTask * task = [[PA2CompositeTask alloc] initWithCancelBlock:nil];
+    
+    // Prepare request packet
+    PA2WCSessionPacket_TimeSync * packetData = [[PA2WCSessionPacket_TimeSync alloc] init];
+    packetData.command = PA2WCSessionPacket_CMD_TIME_SERVICE_GET;
+    PA2WCSessionPacket * packet = [PA2WCSessionPacket packetWithData:packetData target:_target];
+    
+    // Send packet with asynchronous response processing
+    [[PowerAuthWCSessionManager sharedInstance] sendPacketWithResponse:packet responseClass:[PA2WCSessionPacket_Success class] completion:^(PA2WCSessionPacket *response, NSError *error) {
+        if (response) {
+            [self processReceivedPacket:response error:&error];
+        }
+        dispatch_async(callbackQueue, ^{
+            if ([task setCompleted]) {
+                callback(error);
+            }
+        });
+    }];
+    return task;
+}
+
+- (void) resetTimeSynchronization
+{
+    @synchronized (self) {
+        if (_isTimeSynchronized) {
+            PowerAuthLog(@"PA2WatchTimeSynchronizationService: time is no longer synchronized");
+        }
+        _isTimeSynchronized = NO;
+        _localTimeAdjustment = 0.0;
+        _localTimeAdjustmentPrecision = 0.0;
+    }
+}
+
+// MARK: Private methods
+
+- (BOOL) processReceivedPacket:(PA2WCSessionPacket*)packet error:(NSError**)error
+{
+    if (![packet.target isEqualToString:_target]) {
+        PA2SetError(error, PowerAuthErrorCode_Other, @"Wrong target in processReceivedPacket function");
+        return NO;
+    }
+    PA2WCSessionPacket_TimeSync * timeData = [[PA2WCSessionPacket_TimeSync alloc] initWithDictionary:packet.sourceData];
+    if ([timeData validatePacketData]) {
+        if ([timeData.command isEqualToString:PA2WCSessionPacket_CMD_TIME_SERVICE_PUT]) {
+            @synchronized (self) {
+                if (!_isTimeSynchronized) {
+                    PowerAuthLog(@"PA2WatchTimeSynchronizationService: time is now synchronized");
+                }
+                _isTimeSynchronized = YES;
+                _localTimeAdjustment = timeData.localTimeAdjustment;
+                _localTimeAdjustmentPrecision = timeData.localTimeAdjustmentPrecision;
+            }
+            return YES;
+        }
+    }
+    NSString * message = [NSString stringWithFormat:@"PA2WatchTimeSynchronizationService: Received packet has invalid data. Target: %@", packet.target];
+    PA2SetError(error, PowerAuthErrorCode_WatchConnectivity, message);
+    return NO;
+}
+
+// MARK: - PA2WCSessionDataHandler
+
+- (BOOL) canProcessPacket:(PA2WCSessionPacket*)packet
+{
+    return [packet.target isEqualToString:_target];
+}
+
+- (PA2WCSessionDataHandlerResponse*) sessionManager:(PowerAuthWCSessionManager*)manager responseForPacket:(PA2WCSessionPacket*)packet
+{
+    NSError * error = nil;
+    [self processReceivedPacket:packet error:&error];
+    if (error) {
+        return [PA2WCSessionDataHandlerResponse responseWithError:error];
+    }
+    return [PA2WCSessionDataHandlerResponse responseWithPacket:[PA2WCSessionPacket packetWithSuccess]];
+}
+ 
+@end


### PR DESCRIPTION
This PR adds feature that synchronizes time with iOS counterpart. The synchronized time is important for a correct token header calculation.